### PR TITLE
Add counter party channels to registry

### DIFF
--- a/input/penumbra-testnet-deimos-6.json
+++ b/input/penumbra-testnet-deimos-6.json
@@ -15,7 +15,8 @@
     {
       "displayName": "Osmosis",
       "chainId": "osmo-test-5",
-      "ibcChannel": "channel-3",
+      "channelId": "channel-4",
+      "counterpartyChannelId": "channel-7780",
       "addressPrefix": "osmo",
       "cosmosRegistryDir": "testnets/osmosistestnet",
       "images": [
@@ -27,7 +28,8 @@
     {
       "displayName": "Noble",
       "chainId": "grand-1",
-      "ibcChannel": "channel-2",
+      "channelId": "channel-3",
+      "counterpartyChannelId": "channel-164",
       "addressPrefix": "noble",
       "cosmosRegistryDir": "testnets/nobletestnet",
       "images": [

--- a/input/penumbra-testnet-deimos-7.json
+++ b/input/penumbra-testnet-deimos-7.json
@@ -15,7 +15,8 @@
     {
       "displayName": "Osmosis",
       "chainId": "osmo-test-5",
-      "ibcChannel": "channel-4",
+      "channelId": "channel-4",
+      "counterpartyChannelId": "channel-7780",
       "addressPrefix": "osmo",
       "cosmosRegistryDir": "testnets/osmosistestnet",
       "images": [
@@ -27,7 +28,8 @@
     {
       "displayName": "Noble",
       "chainId": "grand-1",
-      "ibcChannel": "channel-3",
+      "channelId": "channel-3",
+      "counterpartyChannelId": "channel-164",
       "addressPrefix": "noble",
       "cosmosRegistryDir": "testnets/nobletestnet",
       "images": [

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @penumbra-labs/registry
 
+## 6.0.0
+
+### Major Changes
+
+- Counterparty chain id added + renamed ibcChannel to channelId
+
 ## 5.2.0
 
 ### Minor Changes

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-labs/registry",
-  "version": "5.2.0",
+  "version": "6.0.0",
   "description": "Chain and asset registry for Penumbra",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/npm/src/registry.test.ts
+++ b/npm/src/registry.test.ts
@@ -10,7 +10,8 @@ const testRegistry: GithubRegistryResponse = {
     {
       addressPrefix: 'osmo',
       chainId: 'osmo-test-5',
-      ibcChannel: 'channel-3',
+      channelId: 'channel-4',
+      counterpartyChannelId: 'channel-7780',
       displayName: 'Osmosis',
       images: [
         {

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -10,7 +10,8 @@ export type Base64AssetId = Stringified<AssetId['inner']>;
 export interface Chain {
   addressPrefix: string;
   chainId: string;
-  ibcChannel: string;
+  channelId: string;
+  counterpartyChannelId: string;
   images: Image[];
   displayName: string;
 }

--- a/registry/penumbra-testnet-deimos-6.json
+++ b/registry/penumbra-testnet-deimos-6.json
@@ -4,7 +4,8 @@
     {
       "addressPrefix": "osmo",
       "chainId": "osmo-test-5",
-      "ibcChannel": "channel-3",
+      "channelId": "channel-4",
+      "counterpartyChannelId": "channel-7780",
       "displayName": "Osmosis",
       "images": [
         {
@@ -15,7 +16,8 @@
     {
       "addressPrefix": "noble",
       "chainId": "grand-1",
-      "ibcChannel": "channel-2",
+      "channelId": "channel-3",
+      "counterpartyChannelId": "channel-164",
       "displayName": "Noble",
       "images": [
         {
@@ -36,24 +38,30 @@
     }
   ],
   "assetById": {
-    "2l5fLuem6wiMOhuIqDF3XGFa20EfBV7XAYmTvKN55Q4=": {
-      "description": "Love is a test tokenfactory asset controlled by the Strangelove Team",
+    "+jDercxZxs90BjC91PrWyA53/p7uN3ZcSJj3N0mHjhI=": {
+      "description": "USDLR is a fiat-backed stablecoin issued by Stable. Stable pays DeFi protocols who distribute USDLR.",
       "denomUnits": [
         {
-          "denom": "transfer/channel-2/ulove"
+          "denom": "transfer/channel-3/uusdlr"
         },
         {
-          "denom": "transfer/channel-2/love",
+          "denom": "transfer/channel-3/usdlr",
           "exponent": 6
         }
       ],
-      "base": "transfer/channel-2/ulove",
-      "display": "transfer/channel-2/love",
-      "name": "Love",
-      "symbol": "LOVE",
+      "base": "transfer/channel-3/uusdlr",
+      "display": "transfer/channel-3/usdlr",
+      "name": "USDLR by Stable",
+      "symbol": "USDLR",
       "penumbraAssetId": {
-        "inner": "2l5fLuem6wiMOhuIqDF3XGFa20EfBV7XAYmTvKN55Q4="
-      }
+        "inner": "+jDercxZxs90BjC91PrWyA53/p7uN3ZcSJj3N0mHjhI="
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/nobletestnet/images/usdlr.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/nobletestnet/images/usdlr.svg"
+        }
+      ]
     },
     "6KBVsPINa8gWSHhfH+kAFJC4afEJA3EtuB2HyCqJUws=": {
       "denomUnits": [
@@ -67,6 +75,30 @@
       "penumbraAssetId": {
         "inner": "6KBVsPINa8gWSHhfH+kAFJC4afEJA3EtuB2HyCqJUws="
       }
+    },
+    "CKBQapu+DkQpsKyTfKESLTV19/NPWR5sNZtvQsd3Hw8=": {
+      "description": "USD Coin",
+      "denomUnits": [
+        {
+          "denom": "transfer/channel-3/uusdc"
+        },
+        {
+          "denom": "transfer/channel-3/usdc",
+          "exponent": 6
+        }
+      ],
+      "base": "transfer/channel-3/uusdc",
+      "display": "transfer/channel-3/usdc",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "penumbraAssetId": {
+        "inner": "CKBQapu+DkQpsKyTfKESLTV19/NPWR5sNZtvQsd3Hw8="
+      },
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
+        }
+      ]
     },
     "CwpUYIdQ9H5Dnf3oQ1l7ISeVMVahWbVNNvMA0dBSdwI=": {
       "denomUnits": [
@@ -94,31 +126,6 @@
         }
       ]
     },
-    "FQo69KceOETEAvrREa1+GAoesN44ISBMleaEz43HCgA=": {
-      "description": "USDLR is a fiat-backed stablecoin issued by Stable. Stable pays DeFi protocols who distribute USDLR.",
-      "denomUnits": [
-        {
-          "denom": "transfer/channel-2/uusdlr"
-        },
-        {
-          "denom": "transfer/channel-2/usdlr",
-          "exponent": 6
-        }
-      ],
-      "base": "transfer/channel-2/uusdlr",
-      "display": "transfer/channel-2/usdlr",
-      "name": "USDLR by Stable",
-      "symbol": "USDLR",
-      "penumbraAssetId": {
-        "inner": "FQo69KceOETEAvrREa1+GAoesN44ISBMleaEz43HCgA="
-      },
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/nobletestnet/images/usdlr.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/nobletestnet/images/usdlr.svg"
-        }
-      ]
-    },
     "HW2Eq3UZVSBttoUwUi/MUtE7rr2UU7/UH500byp7OAc=": {
       "denomUnits": [
         {
@@ -139,6 +146,50 @@
       "penumbraAssetId": {
         "inner": "HW2Eq3UZVSBttoUwUi/MUtE7rr2UU7/UH500byp7OAc="
       }
+    },
+    "Hqn6gTCqE7mCBsVa4agsTFmrO0Rip5xmLcipnGKH9AI=": {
+      "description": "Love is a test tokenfactory asset controlled by the Strangelove Team",
+      "denomUnits": [
+        {
+          "denom": "transfer/channel-3/ulove"
+        },
+        {
+          "denom": "transfer/channel-3/love",
+          "exponent": 6
+        }
+      ],
+      "base": "transfer/channel-3/ulove",
+      "display": "transfer/channel-3/love",
+      "name": "Love",
+      "symbol": "LOVE",
+      "penumbraAssetId": {
+        "inner": "Hqn6gTCqE7mCBsVa4agsTFmrO0Rip5xmLcipnGKH9AI="
+      }
+    },
+    "KSOgqHs6JCHxZcyFPb9zqb2vtdoNlIVktgWcsCF8RAc=": {
+      "description": "The native token of Osmosis",
+      "denomUnits": [
+        {
+          "denom": "transfer/channel-4/uosmo"
+        },
+        {
+          "denom": "transfer/channel-4/osmo",
+          "exponent": 6
+        }
+      ],
+      "base": "transfer/channel-4/uosmo",
+      "display": "transfer/channel-4/osmo",
+      "name": "Osmosis Testnet",
+      "symbol": "OSMO",
+      "penumbraAssetId": {
+        "inner": "KSOgqHs6JCHxZcyFPb9zqb2vtdoNlIVktgWcsCF8RAc="
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+        }
+      ]
     },
     "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=": {
       "denomUnits": [
@@ -166,22 +217,22 @@
         }
       ]
     },
-    "L9R9m9YsAZvGRjGXogRmLJ8n/VUQxHNiNT6dYnuG2QI=": {
+    "ZPcze3Lhpgavnk2eQ/N49hJGttezr+Gl3TiJeL6MvhE=": {
       "denomUnits": [
         {
-          "denom": "transfer/channel-3/factory/osmo1zlkzu72774ynac53necz46u4ycqtp36wedrar0/willyz"
+          "denom": "transfer/channel-4/factory/osmo1zlkzu72774ynac53necz46u4ycqtp36wedrar0/willyz"
         },
         {
-          "denom": "transfer/channel-3/willyz",
+          "denom": "transfer/channel-4/willyz",
           "exponent": 6
         }
       ],
-      "base": "transfer/channel-3/factory/osmo1zlkzu72774ynac53necz46u4ycqtp36wedrar0/willyz",
-      "display": "transfer/channel-3/willyz",
+      "base": "transfer/channel-4/factory/osmo1zlkzu72774ynac53necz46u4ycqtp36wedrar0/willyz",
+      "display": "transfer/channel-4/willyz",
       "name": "Willyz",
       "symbol": "WILLYZ",
       "penumbraAssetId": {
-        "inner": "L9R9m9YsAZvGRjGXogRmLJ8n/VUQxHNiNT6dYnuG2QI="
+        "inner": "ZPcze3Lhpgavnk2eQ/N49hJGttezr+Gl3TiJeL6MvhE="
       },
       "images": [
         {
@@ -190,97 +241,24 @@
         }
       ]
     },
-    "N6cjbF+9/ztCnmEb035XRlDJCgxwm4Q+apv5m73ZGgA=": {
+    "hGwO3SuE1/D05ooLMUVVe7XvYbAFnxAUbIRIZdG3TwI=": {
       "description": "The controlled staking asset for Noble Chain",
       "denomUnits": [
         {
-          "denom": "transfer/channel-2/ustake"
+          "denom": "transfer/channel-3/ustake"
         },
         {
-          "denom": "transfer/channel-2/stake",
+          "denom": "transfer/channel-3/stake",
           "exponent": 6
         }
       ],
-      "base": "transfer/channel-2/ustake",
-      "display": "transfer/channel-2/stake",
+      "base": "transfer/channel-3/ustake",
+      "display": "transfer/channel-3/stake",
       "name": "Stake",
       "symbol": "STAKE",
       "penumbraAssetId": {
-        "inner": "N6cjbF+9/ztCnmEb035XRlDJCgxwm4Q+apv5m73ZGgA="
+        "inner": "hGwO3SuE1/D05ooLMUVVe7XvYbAFnxAUbIRIZdG3TwI="
       }
-    },
-    "drPksQaBNYwSOzgfkGOEdrd4kEDkeALeh58Ps+7cjQs=": {
-      "description": "USD Coin",
-      "denomUnits": [
-        {
-          "denom": "transfer/channel-2/uusdc"
-        },
-        {
-          "denom": "transfer/channel-2/usdc",
-          "exponent": 6
-        }
-      ],
-      "base": "transfer/channel-2/uusdc",
-      "display": "transfer/channel-2/usdc",
-      "name": "USD Coin",
-      "symbol": "USDC",
-      "penumbraAssetId": {
-        "inner": "drPksQaBNYwSOzgfkGOEdrd4kEDkeALeh58Ps+7cjQs="
-      },
-      "images": [
-        {
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
-        }
-      ]
-    },
-    "fLgjA/jT2EN7SFFeKUgZkL8UePmcz5qvNO/CyDBSwQE=": {
-      "description": "The native token of Osmosis",
-      "denomUnits": [
-        {
-          "denom": "transfer/channel-3/uosmo"
-        },
-        {
-          "denom": "transfer/channel-3/osmo",
-          "exponent": 6
-        }
-      ],
-      "base": "transfer/channel-3/uosmo",
-      "display": "transfer/channel-3/osmo",
-      "name": "Osmosis Testnet",
-      "symbol": "OSMO",
-      "penumbraAssetId": {
-        "inner": "fLgjA/jT2EN7SFFeKUgZkL8UePmcz5qvNO/CyDBSwQE="
-      },
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
-        }
-      ]
-    },
-    "jDzeCQh7I0QAuojFcbiG8oSZswf2FwcUUAH57zdMfgk=": {
-      "denomUnits": [
-        {
-          "denom": "transfer/channel-3/uion"
-        },
-        {
-          "denom": "transfer/channel-3/ion",
-          "exponent": 6
-        }
-      ],
-      "base": "transfer/channel-3/uion",
-      "display": "transfer/channel-3/ion",
-      "name": "Ion",
-      "symbol": "ION",
-      "penumbraAssetId": {
-        "inner": "jDzeCQh7I0QAuojFcbiG8oSZswf2FwcUUAH57zdMfgk="
-      },
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
-          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
-        }
-      ]
     },
     "nDjzm+ldIrNMJha1anGMDVxpA5cLCPnUYQ1clmHF1gw=": {
       "denomUnits": [
@@ -368,10 +346,35 @@
           "svg": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/test-usd.svg"
         }
       ]
+    },
+    "xNdg/Pc2CvrtawUX41EBLTlgj83RTenRJaBFXxsSTwk=": {
+      "denomUnits": [
+        {
+          "denom": "transfer/channel-4/uion"
+        },
+        {
+          "denom": "transfer/channel-4/ion",
+          "exponent": 6
+        }
+      ],
+      "base": "transfer/channel-4/uion",
+      "display": "transfer/channel-4/ion",
+      "name": "Ion",
+      "symbol": "ION",
+      "penumbraAssetId": {
+        "inner": "xNdg/Pc2CvrtawUX41EBLTlgj83RTenRJaBFXxsSTwk="
+      },
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.png",
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
+        }
+      ]
     }
   },
   "stakingAssetId": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=",
   "numeraires": [
-    "reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg="
+    "reum7wQmk/owgvGMWMZn/6RFPV24zIKq3W6In/WwZgg=",
+    "CKBQapu+DkQpsKyTfKESLTV19/NPWR5sNZtvQsd3Hw8="
   ]
 }

--- a/registry/penumbra-testnet-deimos-7.json
+++ b/registry/penumbra-testnet-deimos-7.json
@@ -4,7 +4,8 @@
     {
       "addressPrefix": "osmo",
       "chainId": "osmo-test-5",
-      "ibcChannel": "channel-4",
+      "channelId": "channel-4",
+      "counterpartyChannelId": "channel-7780",
       "displayName": "Osmosis",
       "images": [
         {
@@ -15,7 +16,8 @@
     {
       "addressPrefix": "noble",
       "chainId": "grand-1",
-      "ibcChannel": "channel-3",
+      "channelId": "channel-3",
+      "counterpartyChannelId": "channel-164",
       "displayName": "Noble",
       "images": [
         {

--- a/tools/compiler/src/parser.rs
+++ b/tools/compiler/src/parser.rs
@@ -35,7 +35,8 @@ pub struct Image {
 #[serde(rename_all = "camelCase")]
 pub struct IbcInput {
     pub chain_id: String,
-    pub ibc_channel: String,
+    pub channel_id: String,
+    pub counterparty_channel_id: String,
     pub address_prefix: String,
     pub cosmos_registry_dir: String,
     pub display_name: String,

--- a/tools/compiler/src/processor.rs
+++ b/tools/compiler/src/processor.rs
@@ -21,7 +21,8 @@ use crate::querier::query_github_assets;
 pub struct Chain {
     pub address_prefix: String,
     pub chain_id: String,
-    pub ibc_channel: String,
+    pub channel_id: String,
+    pub counterparty_channel_id: String,
     pub display_name: String,
     pub images: Vec<Image>,
 }
@@ -31,7 +32,8 @@ impl From<IbcInput> for Chain {
         Chain {
             address_prefix: config.address_prefix,
             chain_id: config.chain_id,
-            ibc_channel: config.ibc_channel,
+            channel_id: config.channel_id,
+            counterparty_channel_id: config.counterparty_channel_id,
             display_name: config.display_name,
             images: config.images,
         }
@@ -83,7 +85,7 @@ pub fn transport_metadata_along_channel(
     tracing::debug!(?pb_metadata, "original");
 
     let prefix_channel = |x: &mut String| {
-        *x = format!("transfer/{}/{}", ibc_data.ibc_channel, x);
+        *x = format!("transfer/{}/{}", ibc_data.channel_id, x);
     };
 
     // Prefix the channel to the base denom.

--- a/tools/compiler/tests/test_processor.rs
+++ b/tools/compiler/tests/test_processor.rs
@@ -22,7 +22,8 @@ fn base64_id_extracts_correctly() {
 #[test]
 fn test_transport_metadata_along_channel() {
     let ibc_data = IbcInput {
-        ibc_channel: "channel-123".to_string(),
+        channel_id: "channel-123".to_string(),
+        counterparty_channel_id: "channel-456".to_string(),
         chain_id: "love-999".to_string(),
         address_prefix: "love".to_string(),
         cosmos_registry_dir: "love-124".to_string(),


### PR DESCRIPTION
Consumers need to know what is the counterparty channel id for our IBC connections. Instead of having to query+map for this data, we'll just add them to the registry.

<img width="1198" alt="Screenshot 2024-05-06 at 9 59 16 AM" src="https://github.com/prax-wallet/registry/assets/16624263/00e8699b-b612-4579-961d-edbafb4cfea8">
