### PR TITLE
Make rpcs+frontends global values

### DIFF
--- a/input/chains/penumbra-testnet-deimos-6.json
+++ b/input/chains/penumbra-testnet-deimos-6.json
@@ -1,25 +1,11 @@
 {
-  "chainId": "penumbra-testnet-deimos-8",
-  "rpcs": [
-    {
-      "name": "Penumbra Labs Testnet RPC",
-      "url": "https://grpc.testnet.penumbra.zone",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
-        }
-      ]
-    }
-  ],
-  "frontends": [
-    "https://app.testnet.penumbra.zone"
-  ],
+  "chainId": "penumbra-testnet-deimos-6",
   "ibcConnections": [
     {
       "displayName": "Osmosis",
       "chainId": "osmo-test-5",
-      "channelId": "channel-5",
-      "counterpartyChannelId": "channel-8007",
+      "channelId": "channel-4",
+      "counterpartyChannelId": "channel-7780",
       "addressPrefix": "osmo",
       "cosmosRegistryDir": "testnets/osmosistestnet",
       "images": [
@@ -31,8 +17,8 @@
     {
       "displayName": "Noble",
       "chainId": "grand-1",
-      "channelId": "channel-6",
-      "counterpartyChannelId": "channel-176",
+      "channelId": "channel-3",
+      "counterpartyChannelId": "channel-164",
       "addressPrefix": "noble",
       "cosmosRegistryDir": "testnets/nobletestnet",
       "images": [
@@ -42,35 +28,7 @@
       ]
     }
   ],
-  "validators": [
-    {
-      "name": "Penumbra Labs CI 1",
-      "base": "udelegation_penumbravalid1sqwq8p8fqxx4aflthtwmu6kte8je7sh4tj7pyd82qpvdap5ajgrsv0q0ja",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
-        }
-      ]
-    },
-    {
-      "name": "Penumbra Labs CI 2",
-      "base": "udelegation_penumbravalid173zelmfxtk7r5mhj0k9n96zh9amkr0aucjtsj9j7rdyuj05f4yyqqg5w63",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
-        }
-      ]
-    },
-    {
-      "name": "Starling Staking",
-      "base": "udelegation_penumbravalid1gjdvn0u85rgldqk5adfexn6n4y8d2m3tfla54sc4gu95xwpzssxsjutk7u",
-      "images": [
-        {
-          "svg": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/starling-staking.svg"
-        }
-      ]
-    }
-  ],
+  "validators": [],
   "nativeAssets": [
     {
       "denomUnits": [
@@ -117,12 +75,7 @@
       "symbol": "GM",
       "penumbraAssetId": {
         "inner": "HW2Eq3UZVSBttoUwUi/MUtE7rr2UU7/UH500byp7OAc="
-      },
-      "images": [
-        {
-          "svg": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/full-moon-face.svg"
-        }
-      ]
+      }
     },
     {
       "denomUnits": [
@@ -143,12 +96,7 @@
       "symbol": "GN",
       "penumbraAssetId": {
         "inner": "nwPDkQq3OvLnBwGTD+nmv1Ifb2GEmFCgNHrU++9BsRE="
-      },
-      "images": [
-        {
-          "svg": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/new-moon-face.svg"
-        }
-      ]
+      }
     },
     {
       "denomUnits": [
@@ -206,82 +154,58 @@
     {
       "denomUnits": [
         {
-          "denom": "test_eth",
-          "exponent": 18
-        },
-        {
-          "denom": "wtest_eth"
-        }
-      ],
-      "base": "wtest_eth",
-      "display": "test_eth",
-      "symbol": "TestETH",
-      "penumbraAssetId": {
-        "inner": "HLkKbVfA72oQaMdYFroWQ1qoSyl/KLHZiOMJhL2y9w0="
-      }
-    },
-    {
-      "denomUnits": [
-        {
-          "denom": "test_btc",
-          "exponent": 8
-        },
-        {
-          "denom": "test_sat"
-        }
-      ],
-      "base": "test_sat",
-      "display": "test_btc",
-      "symbol": "TestBTC",
-      "penumbraAssetId": {
-        "inner": "o2gZdbhCH70Ry+7iBhkSeHC/PB1LZhgkn7LHC2kEhQc="
-      }
-    },
-    {
-      "denomUnits": [
-        {
-          "denom": "test_atom",
+          "denom": "delegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
           "exponent": 6
         },
         {
-          "denom": "mtest_atom",
+          "denom": "mdelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
           "exponent": 3
         },
         {
-          "denom": "utest_atom"
+          "denom": "udelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20"
         }
       ],
-      "base": "utest_atom",
-      "display": "test_atom",
-      "symbol": "TestATOM",
+      "base": "udelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
+      "display": "delegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
       "penumbraAssetId": {
-        "inner": "ypUT1AOtjfwMOKMATACoD9RSvi8jY/YnYGi46CZ/6Q8="
-      }
+        "inner": "CwpUYIdQ9H5Dnf3oQ1l7ISeVMVahWbVNNvMA0dBSdwI="
+      },
+      "symbol": "Delegation (Penumbra Labs CI 1)",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
+        }
+      ]
     },
     {
       "denomUnits": [
         {
-          "denom": "test_osmo",
+          "denom": "delegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
           "exponent": 6
         },
         {
-          "denom": "mtest_osmo",
+          "denom": "mdelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
           "exponent": 3
         },
         {
-          "denom": "utest_osmo"
+          "denom": "udelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050"
         }
       ],
-      "base": "utest_osmo",
-      "display": "test_osmo",
-      "symbol": "TestOSMO",
+      "base": "udelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
+      "display": "delegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
       "penumbraAssetId": {
-        "inner": "pmpygqUf4DL+z849rGPpudpdK/+FAv8qQ01U2C73kAw="
-      }
+        "inner": "qUn70lKZ3qQlCT5gj5sakux4daiTPKj0AN6ZuuFldQU="
+      },
+      "symbol": "Delegation (Penumbra Labs CI 2)",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
+        }
+      ]
     }
   ],
   "canonicalNumeraires": [
     "wtest_usd",
-    "transfer/channel-6/uusdc"
+    "transfer/channel-3/uusdc"
   ]
 }

--- a/input/chains/penumbra-testnet-deimos-7.json
+++ b/input/chains/penumbra-testnet-deimos-7.json
@@ -1,19 +1,5 @@
 {
   "chainId": "penumbra-testnet-deimos-7",
-  "rpcs": [
-    {
-      "name": "Penumbra Labs Testnet RPC",
-      "url": "https://grpc.testnet.penumbra.zone",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
-        }
-      ]
-    }
-  ],
-  "frontends": [
-    "https://app.testnet.penumbra.zone"
-  ],
   "ibcConnections": [
     {
       "displayName": "Osmosis",

--- a/input/chains/penumbra-testnet-deimos-8.json
+++ b/input/chains/penumbra-testnet-deimos-8.json
@@ -1,25 +1,11 @@
 {
-  "chainId": "penumbra-testnet-deimos-6",
-  "rpcs": [
-    {
-      "name": "Penumbra Labs Testnet RPC",
-      "url": "https://grpc.testnet.penumbra.zone",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
-        }
-      ]
-    }
-  ],
-  "frontends": [
-    "https://app.testnet.penumbra.zone"
-  ],
+  "chainId": "penumbra-testnet-deimos-8",
   "ibcConnections": [
     {
       "displayName": "Osmosis",
       "chainId": "osmo-test-5",
-      "channelId": "channel-4",
-      "counterpartyChannelId": "channel-7780",
+      "channelId": "channel-5",
+      "counterpartyChannelId": "channel-8007",
       "addressPrefix": "osmo",
       "cosmosRegistryDir": "testnets/osmosistestnet",
       "images": [
@@ -31,8 +17,8 @@
     {
       "displayName": "Noble",
       "chainId": "grand-1",
-      "channelId": "channel-3",
-      "counterpartyChannelId": "channel-164",
+      "channelId": "channel-6",
+      "counterpartyChannelId": "channel-176",
       "addressPrefix": "noble",
       "cosmosRegistryDir": "testnets/nobletestnet",
       "images": [
@@ -42,7 +28,35 @@
       ]
     }
   ],
-  "validators": [],
+  "validators": [
+    {
+      "name": "Penumbra Labs CI 1",
+      "base": "udelegation_penumbravalid1sqwq8p8fqxx4aflthtwmu6kte8je7sh4tj7pyd82qpvdap5ajgrsv0q0ja",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
+        }
+      ]
+    },
+    {
+      "name": "Penumbra Labs CI 2",
+      "base": "udelegation_penumbravalid173zelmfxtk7r5mhj0k9n96zh9amkr0aucjtsj9j7rdyuj05f4yyqqg5w63",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
+        }
+      ]
+    },
+    {
+      "name": "Starling Staking",
+      "base": "udelegation_penumbravalid1gjdvn0u85rgldqk5adfexn6n4y8d2m3tfla54sc4gu95xwpzssxsjutk7u",
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/starling-staking.svg"
+        }
+      ]
+    }
+  ],
   "nativeAssets": [
     {
       "denomUnits": [
@@ -89,7 +103,12 @@
       "symbol": "GM",
       "penumbraAssetId": {
         "inner": "HW2Eq3UZVSBttoUwUi/MUtE7rr2UU7/UH500byp7OAc="
-      }
+      },
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/full-moon-face.svg"
+        }
+      ]
     },
     {
       "denomUnits": [
@@ -110,7 +129,12 @@
       "symbol": "GN",
       "penumbraAssetId": {
         "inner": "nwPDkQq3OvLnBwGTD+nmv1Ifb2GEmFCgNHrU++9BsRE="
-      }
+      },
+      "images": [
+        {
+          "svg": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/new-moon-face.svg"
+        }
+      ]
     },
     {
       "denomUnits": [
@@ -168,58 +192,82 @@
     {
       "denomUnits": [
         {
-          "denom": "delegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
-          "exponent": 6
+          "denom": "test_eth",
+          "exponent": 18
         },
         {
-          "denom": "mdelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
-          "exponent": 3
-        },
-        {
-          "denom": "udelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20"
+          "denom": "wtest_eth"
         }
       ],
-      "base": "udelegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
-      "display": "delegation_penumbravalid18nkv0r3sfp2seleq6du5kt3mhfce3k6cqm77kj2e7mhakmyw9v9qx42a20",
+      "base": "wtest_eth",
+      "display": "test_eth",
+      "symbol": "TestETH",
       "penumbraAssetId": {
-        "inner": "CwpUYIdQ9H5Dnf3oQ1l7ISeVMVahWbVNNvMA0dBSdwI="
-      },
-      "symbol": "Delegation (Penumbra Labs CI 1)",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
-        }
-      ]
+        "inner": "HLkKbVfA72oQaMdYFroWQ1qoSyl/KLHZiOMJhL2y9w0="
+      }
     },
     {
       "denomUnits": [
         {
-          "denom": "delegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
+          "denom": "test_btc",
+          "exponent": 8
+        },
+        {
+          "denom": "test_sat"
+        }
+      ],
+      "base": "test_sat",
+      "display": "test_btc",
+      "symbol": "TestBTC",
+      "penumbraAssetId": {
+        "inner": "o2gZdbhCH70Ry+7iBhkSeHC/PB1LZhgkn7LHC2kEhQc="
+      }
+    },
+    {
+      "denomUnits": [
+        {
+          "denom": "test_atom",
           "exponent": 6
         },
         {
-          "denom": "mdelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
+          "denom": "mtest_atom",
           "exponent": 3
         },
         {
-          "denom": "udelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050"
+          "denom": "utest_atom"
         }
       ],
-      "base": "udelegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
-      "display": "delegation_penumbravalid1qfxldejdhanmu302kcn5fm98q5d7d2upfhzqhaz95hyjdn82pqysqfq050",
+      "base": "utest_atom",
+      "display": "test_atom",
+      "symbol": "TestATOM",
       "penumbraAssetId": {
-        "inner": "qUn70lKZ3qQlCT5gj5sakux4daiTPKj0AN6ZuuFldQU="
-      },
-      "symbol": "Delegation (Penumbra Labs CI 2)",
-      "images": [
+        "inner": "ypUT1AOtjfwMOKMATACoD9RSvi8jY/YnYGi46CZ/6Q8="
+      }
+    },
+    {
+      "denomUnits": [
         {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
+          "denom": "test_osmo",
+          "exponent": 6
+        },
+        {
+          "denom": "mtest_osmo",
+          "exponent": 3
+        },
+        {
+          "denom": "utest_osmo"
         }
-      ]
+      ],
+      "base": "utest_osmo",
+      "display": "test_osmo",
+      "symbol": "TestOSMO",
+      "penumbraAssetId": {
+        "inner": "pmpygqUf4DL+z849rGPpudpdK/+FAv8qQ01U2C73kAw="
+      }
     }
   ],
   "canonicalNumeraires": [
     "wtest_usd",
-    "transfer/channel-3/uusdc"
+    "transfer/channel-6/uusdc"
   ]
 }

--- a/input/globals.json
+++ b/input/globals.json
@@ -1,0 +1,16 @@
+{
+  "rpcs": [
+    {
+      "name": "Penumbra Labs Testnet RPC",
+      "url": "https://grpc.testnet.penumbra.zone",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
+        }
+      ]
+    }
+  ],
+  "frontends": [
+    "https://app.testnet.penumbra.zone"
+  ]
+}

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @penumbra-labs/registry
 
+## 8.0.0
+
+### Major Changes
+
+- New API for global rpcs & frontends
+
 ## 7.7.0
 
 ### Minor Changes

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-labs/registry",
-  "version": "7.7.0",
+  "version": "8.0.0",
   "description": "Chain and asset registry for Penumbra",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/npm/src/client.ts
+++ b/npm/src/client.ts
@@ -1,6 +1,6 @@
 import { deriveTestnetChainIdFromPreview, isTestnetPreviewChainId } from './utils/testnet-parser';
 import { Registry } from './registry';
-import { allJsonRegistries } from './json';
+import { allJsonRegistries, registryGlobals, RegistryGlobals } from './json';
 
 export class ChainRegistryClient {
   get(chainId: string): Registry {
@@ -11,6 +11,10 @@ export class ChainRegistryClient {
     }
 
     return new Registry(jsonRegistry);
+  }
+
+  globals(): RegistryGlobals {
+    return registryGlobals;
   }
 
   version() {

--- a/npm/src/json.ts
+++ b/npm/src/json.ts
@@ -1,14 +1,18 @@
-import * as Deimos6 from '../../registry/penumbra-testnet-deimos-6.json';
-import * as Deimos7 from '../../registry/penumbra-testnet-deimos-7.json';
-import * as Deimos8 from '../../registry/penumbra-testnet-deimos-8.json';
+import * as Deimos6 from '../../registry/chains/penumbra-testnet-deimos-6.json';
+import * as Deimos7 from '../../registry/chains/penumbra-testnet-deimos-7.json';
+import * as Deimos8 from '../../registry/chains/penumbra-testnet-deimos-8.json';
+import * as GlobalsJson from '../../registry/globals.json';
 
 import { Base64AssetId, Chain, Rpc } from './registry';
+
+export interface RegistryGlobals {
+  rpcs: Rpc[];
+  frontends: string[];
+}
 
 export interface JsonRegistry {
   chainId: string;
   ibcConnections: Chain[];
-  rpcs: Rpc[];
-  frontends: string[];
   assetById: Record<Base64AssetId, JsonMetadata>;
   stakingAssetId: Base64AssetId;
   numeraires: Base64AssetId[];
@@ -44,3 +48,5 @@ export const allJsonRegistries: Record<string, JsonRegistry> = {
   'penumbra-testnet-deimos-7': Deimos7,
   'penumbra-testnet-deimos-8': Deimos8,
 };
+
+export const registryGlobals = GlobalsJson;

--- a/npm/src/registry.test.ts
+++ b/npm/src/registry.test.ts
@@ -20,18 +20,6 @@ const testRegistry: JsonRegistry = {
       ],
     },
   ],
-  rpcs: [
-    {
-      name: 'Penumbra Labs Testnet RPC',
-      url: 'https://grpc.testnet.penumbra.zone',
-      images: [
-        {
-          png: 'https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png',
-        },
-      ],
-    },
-  ],
-  frontends: ['https://app.testnet.penumbra.zone'],
   assetById: {
     'KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=': {
       denomUnits: [
@@ -105,11 +93,5 @@ describe('Registry', () => {
     const registry = new Registry(testRegistry);
     const res = registry.getAllAssets();
     expect(res.length).toEqual(2);
-  });
-
-  it('frontends are accessible', () => {
-    const registry = new Registry(testRegistry);
-    expect(registry.frontends.length).toEqual(1);
-    expect(registry.frontends[0]).toEqual('https://app.testnet.penumbra.zone');
   });
 });

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -36,8 +36,6 @@ export interface Image {
 export class Registry {
   public readonly chainId: string;
   public readonly ibcConnections: Chain[];
-  public readonly rpcs: Rpc[];
-  public readonly frontends: string[];
   public readonly stakingAssetId: AssetId;
   public readonly numeraires: AssetId[];
 
@@ -46,8 +44,6 @@ export class Registry {
   constructor(r: JsonRegistry) {
     this.chainId = r.chainId;
     this.ibcConnections = r.ibcConnections;
-    this.rpcs = r.rpcs;
-    this.frontends = r.frontends;
     this.assetById = mapObjectValues(r.assetById, jsonMetadata =>
       Metadata.fromJson(jsonMetadata as unknown as JsonValue),
     );

--- a/registry/chains/penumbra-testnet-deimos-6.json
+++ b/registry/chains/penumbra-testnet-deimos-6.json
@@ -1,5 +1,5 @@
 {
-  "chainId": "penumbra-testnet-deimos-7",
+  "chainId": "penumbra-testnet-deimos-6",
   "ibcConnections": [
     {
       "addressPrefix": "osmo",
@@ -22,20 +22,6 @@
       "images": [
         {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/2ca39d0e4eaf3431cca13991948e099801f02e46/noble/images/stake.svg"
-        }
-      ]
-    }
-  ],
-  "frontends": [
-    "https://app.testnet.penumbra.zone"
-  ],
-  "rpcs": [
-    {
-      "name": "Penumbra Labs Testnet RPC",
-      "url": "https://grpc.testnet.penumbra.zone",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
         }
       ]
     }

--- a/registry/chains/penumbra-testnet-deimos-7.json
+++ b/registry/chains/penumbra-testnet-deimos-7.json
@@ -1,5 +1,5 @@
 {
-  "chainId": "penumbra-testnet-deimos-6",
+  "chainId": "penumbra-testnet-deimos-7",
   "ibcConnections": [
     {
       "addressPrefix": "osmo",
@@ -22,20 +22,6 @@
       "images": [
         {
           "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/2ca39d0e4eaf3431cca13991948e099801f02e46/noble/images/stake.svg"
-        }
-      ]
-    }
-  ],
-  "frontends": [
-    "https://app.testnet.penumbra.zone"
-  ],
-  "rpcs": [
-    {
-      "name": "Penumbra Labs Testnet RPC",
-      "url": "https://grpc.testnet.penumbra.zone",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
         }
       ]
     }

--- a/registry/chains/penumbra-testnet-deimos-8.json
+++ b/registry/chains/penumbra-testnet-deimos-8.json
@@ -26,20 +26,6 @@
       ]
     }
   ],
-  "frontends": [
-    "https://app.testnet.penumbra.zone"
-  ],
-  "rpcs": [
-    {
-      "name": "Penumbra Labs Testnet RPC",
-      "url": "https://grpc.testnet.penumbra.zone",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
-        }
-      ]
-    }
-  ],
   "assetById": {
     "/5AHh95RAybBbUhQ5zXMWCvstH4rRK/5KMVIVGQltAw=": {
       "denomUnits": [

--- a/registry/globals.json
+++ b/registry/globals.json
@@ -1,0 +1,16 @@
+{
+  "rpcs": [
+    {
+      "name": "Penumbra Labs Testnet RPC",
+      "url": "https://grpc.testnet.penumbra.zone",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/penumbra-favicon.png"
+        }
+      ]
+    }
+  ],
+  "frontends": [
+    "https://app.testnet.penumbra.zone"
+  ]
+}

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -651,8 +651,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.77.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.77.1#13f81d0792ffd1b03b7ac169544f1d3663013272"
+version = "0.77.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.77.2#76aab4b843f47b7ce9d7177196fdd2495ccf7bfa"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -2042,8 +2042,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.77.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.77.1#13f81d0792ffd1b03b7ac169544f1d3663013272"
+version = "0.77.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.77.2#76aab4b843f47b7ce9d7177196fdd2495ccf7bfa"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2080,8 +2080,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.77.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.77.1#13f81d0792ffd1b03b7ac169544f1d3663013272"
+version = "0.77.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.77.2#76aab4b843f47b7ce9d7177196fdd2495ccf7bfa"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2116,8 +2116,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.77.1"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.77.1#13f81d0792ffd1b03b7ac169544f1d3663013272"
+version = "0.77.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.77.2#76aab4b843f47b7ce9d7177196fdd2495ccf7bfa"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.77.1", package = "penumbra-asset" }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.77.1", package = "penumbra-proto", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.77.2", package = "penumbra-asset" }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.77.2", package = "penumbra-proto", default-features = false }
 
 anyhow = "1.0.86"
 futures = "0.3.30"

--- a/tools/compiler/tests/test_copy_globals.rs
+++ b/tools/compiler/tests/test_copy_globals.rs
@@ -1,0 +1,71 @@
+use penumbra_registry::parser::{copy_globals, Globals, Rpc};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+use tempdir::TempDir;
+
+fn create_file_with_content(dir: &Path, file_name: &str, content: &str) {
+    let file_path = dir.join(file_name);
+    let mut file = File::create(file_path).unwrap();
+    writeln!(file, "{}", content).unwrap();
+}
+
+#[test]
+fn test_successful_copy() {
+    let temp_input_dir = TempDir::new("").unwrap();
+    let temp_output_dir = TempDir::new("").unwrap();
+    let globals = Globals {
+        rpcs: vec![Rpc {
+            name: "cybernetics".to_string(),
+            url: "http://api.zone".to_string(),
+            images: vec![],
+        }],
+        frontends: vec!["http://frontend.zone".to_string()],
+    };
+    create_file_with_content(
+        temp_input_dir.path(),
+        "globals.json",
+        &serde_json::to_string(&globals).unwrap(),
+    );
+
+    assert!(copy_globals(
+        temp_input_dir.path().to_str().unwrap(),
+        temp_output_dir.path().to_str().unwrap()
+    )
+    .is_ok());
+
+    let output_path = temp_output_dir.path().join("globals.json");
+    let output_contents = fs::read_to_string(output_path).unwrap();
+    let output_globals: Globals = serde_json::from_str(&output_contents).unwrap();
+
+    assert_eq!(output_globals, globals);
+}
+
+#[test]
+fn test_file_not_found() {
+    let temp_input_dir = TempDir::new("").unwrap();
+    let temp_output_dir = TempDir::new("").unwrap();
+
+    assert!(copy_globals(
+        temp_input_dir.path().to_str().unwrap(),
+        temp_output_dir.path().to_str().unwrap()
+    )
+    .is_err());
+}
+
+#[test]
+fn test_invalid_json_format() {
+    let temp_input_dir = TempDir::new("").unwrap();
+    let temp_output_dir = TempDir::new("").unwrap();
+    create_file_with_content(
+        temp_input_dir.path(),
+        "globals.json",
+        "This is not valid JSON",
+    );
+
+    assert!(copy_globals(
+        temp_input_dir.path().to_str().unwrap(),
+        temp_output_dir.path().to_str().unwrap()
+    )
+    .is_err());
+}

--- a/tools/compiler/tests/test_get_chain_configs.rs
+++ b/tools/compiler/tests/test_get_chain_configs.rs
@@ -5,7 +5,10 @@ use std::path::Path;
 use tempdir::TempDir;
 
 fn create_test_config_file(dir: &Path, file_name: &str, contents: &str) {
-    let file_path = dir.join(file_name);
+    let chains_dir = dir.join("chains");
+    std::fs::create_dir_all(&chains_dir).unwrap();
+
+    let file_path = chains_dir.join(file_name);
     let mut file = File::create(file_path).unwrap();
     file.write_all(contents.as_bytes()).unwrap();
 }
@@ -13,7 +16,6 @@ fn create_test_config_file(dir: &Path, file_name: &str, contents: &str) {
 #[test]
 fn test_get_chain_configs_reads_configs_correctly() {
     let temp_input_dir = TempDir::new("test_input").unwrap();
-    let temp_registry_dir = TempDir::new("test_registry").unwrap();
 
     let config_content = serde_json::json!({
         "chainId": "test-chain-1",
@@ -27,11 +29,7 @@ fn test_get_chain_configs_reads_configs_correctly() {
     .to_string();
     create_test_config_file(temp_input_dir.path(), "test-chain-1.json", &config_content);
 
-    let configs = get_chain_configs(
-        temp_registry_dir.path().to_str().unwrap(),
-        temp_input_dir.path().to_str().unwrap(),
-    )
-    .unwrap();
+    let configs = get_chain_configs(temp_input_dir.path().to_str().unwrap()).unwrap();
     assert_eq!(configs.len(), 1);
     assert_eq!(configs[0].chain_id, "test-chain-1");
 }
@@ -39,7 +37,6 @@ fn test_get_chain_configs_reads_configs_correctly() {
 #[test]
 fn test_get_chain_configs_reads_multiple_configs_correctly() {
     let temp_input_dir = TempDir::new("test_input").unwrap();
-    let temp_registry_dir = TempDir::new("test_registry").unwrap();
 
     let config_content_1 = serde_json::json!({
         "chainId": "test-chain-1",
@@ -75,11 +72,7 @@ fn test_get_chain_configs_reads_multiple_configs_correctly() {
         &config_content_2,
     );
 
-    let configs = get_chain_configs(
-        temp_registry_dir.path().to_str().unwrap(),
-        temp_input_dir.path().to_str().unwrap(),
-    )
-    .unwrap();
+    let configs = get_chain_configs(temp_input_dir.path().to_str().unwrap()).unwrap();
 
     assert_eq!(configs.len(), 2);
     assert!(configs
@@ -93,7 +86,6 @@ fn test_get_chain_configs_reads_multiple_configs_correctly() {
 #[test]
 fn test_get_chain_configs_handles_invalid_json() {
     let temp_input_dir = TempDir::new("test_input").unwrap();
-    let temp_registry_dir = TempDir::new("test_registry").unwrap();
 
     let invalid_config_content = "{ invalid json }";
     create_test_config_file(
@@ -102,11 +94,7 @@ fn test_get_chain_configs_handles_invalid_json() {
         invalid_config_content,
     );
 
-    let configs = get_chain_configs(
-        temp_registry_dir.path().to_str().unwrap(),
-        temp_input_dir.path().to_str().unwrap(),
-    )
-    .unwrap();
+    let configs = get_chain_configs(temp_input_dir.path().to_str().unwrap()).unwrap();
 
     assert_eq!(configs.len(), 0);
 }

--- a/tools/compiler/tests/test_reset_registry_dir.rs
+++ b/tools/compiler/tests/test_reset_registry_dir.rs
@@ -1,0 +1,46 @@
+use penumbra_registry::parser::reset_registry_dir;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+use tempdir::TempDir;
+
+fn create_file_in_dir(dir: &Path, file_name: &str) {
+    let file_path = dir.join(file_name);
+    let mut file = File::create(file_path).unwrap();
+    writeln!(file, "Test content").unwrap();
+}
+
+fn create_subdir_in_dir(dir: &Path, subdir_name: &str) {
+    let subdir_path = dir.join(subdir_name);
+    fs::create_dir_all(subdir_path).unwrap();
+}
+
+#[test]
+fn test_reset_non_existent_directory() {
+    let temp_dir = TempDir::new("").unwrap();
+    let non_existent_dir = temp_dir.path().join("nonexistent");
+
+    reset_registry_dir(non_existent_dir.to_str().unwrap()).unwrap();
+    assert!(non_existent_dir.exists());
+    assert!(non_existent_dir.join("chains").exists());
+}
+
+#[test]
+fn test_reset_existing_directory_with_files() {
+    let temp_dir = TempDir::new("").unwrap();
+    create_file_in_dir(temp_dir.path(), "testfile.txt");
+
+    reset_registry_dir(temp_dir.path().to_str().unwrap()).unwrap();
+    assert!(temp_dir.path().join("chains").exists());
+    assert!(!temp_dir.path().join("testfile.txt").exists());
+}
+
+#[test]
+fn test_reset_existing_directory_with_subdirectories() {
+    let temp_dir = TempDir::new("").unwrap();
+    create_subdir_in_dir(temp_dir.path(), "subdir");
+
+    reset_registry_dir(temp_dir.path().to_str().unwrap()).unwrap();
+    assert!(temp_dir.path().join("chains").exists());
+    assert!(!temp_dir.path().join("subdir").exists());
+}


### PR DESCRIPTION
Previously, you needed a chain id to get rpcs+frontends. This PR makes those available without the need for a chain id.

Also adds various helpers+tests. 