### PR TITLE
feat: #62: add support for local devnets

### DIFF
--- a/npm/.changeset/metal-toys-unite.md
+++ b/npm/.changeset/metal-toys-unite.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-labs/registry': patch
+---
+
+Add support for local devnet chain IDs

--- a/npm/src/utils/testnet-parser.test.ts
+++ b/npm/src/utils/testnet-parser.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { deriveTestnetChainIdFromPreview, isTestnetPreviewChainId } from './testnet-parser';
 
 describe('testnet-preview helper', () => {
+  it('should correctly identify local testnet chain-id', () => {
+    expect(isTestnetPreviewChainId('penumbra-testnet-deimos-8-f75c2ba6')).toBeTruthy();
+    expect(isTestnetPreviewChainId('penumbra-testnet-deimos-8-f2dbce94')).toBeTruthy();
+    expect(isTestnetPreviewChainId('penumbra-testnet-deimos-0044bb22')).toBeTruthy();
+    expect(isTestnetPreviewChainId('penumbra-testnet-rhea-ff99ee10')).toBeTruthy();
+    expect(isTestnetPreviewChainId('penumbra-testnet-tethy12-b4d8f9a0')).toBeTruthy();
+  });
+
   it('should correctly identify testnet-preview chain-id', () => {
     expect(isTestnetPreviewChainId('penumbra-testnet-deimos-8-xf2dbce94')).toBeTruthy();
     expect(isTestnetPreviewChainId('penumbra-testnet-deimos-x0044bb22')).toBeTruthy();
@@ -13,6 +21,7 @@ describe('testnet-preview helper', () => {
     expect(isTestnetPreviewChainId('penumbra-mainnet')).toBeFalsy();
     expect(isTestnetPreviewChainId('penumbra-testnet-rhea')).toBeFalsy();
     expect(isTestnetPreviewChainId('penumbra-testnet-deimos-6')).toBeFalsy();
+    expect(isTestnetPreviewChainId('penumbra-testnet-deimos-8-abc')).toBeFalsy();
   });
 
   it('should correctly derive testnet chain-id from testnet-preview chain-id', () => {
@@ -23,6 +32,9 @@ describe('testnet-preview helper', () => {
       'penumbra-testnet-rhea',
     );
     expect(deriveTestnetChainIdFromPreview('penumbra-testnet-tethys12-xb4d8f9a0')).toEqual(
+      'penumbra-testnet-tethys12',
+    );
+    expect(deriveTestnetChainIdFromPreview('penumbra-testnet-tethys12-b4d8f9a0')).toEqual(
       'penumbra-testnet-tethys12',
     );
   });

--- a/npm/src/utils/testnet-parser.ts
+++ b/npm/src/utils/testnet-parser.ts
@@ -1,10 +1,13 @@
-// Test preview chain ids end with -x followed by a hexadecimal string
+const testnetChainIdPattern = /-x?[0-9a-f]{8}$/;
+
+/**
+ * Preview chain ids end with '-x' followed by a hexadecimal string of length 8
+ * Local chain ids end with a '-' followed by a hexadecimal string of length 8
+ */
 export const isTestnetPreviewChainId = (chainId: string): boolean => {
-  const previewRegex = /-x[0-9a-f]+$/i;
-  return previewRegex.test(chainId);
+  return testnetChainIdPattern.test(chainId);
 };
 
 export const deriveTestnetChainIdFromPreview = (previewChainId: string): string => {
-  const index = previewChainId.lastIndexOf('-x');
-  return previewChainId.substring(0, index);
+  return previewChainId.substring(0, previewChainId.search(testnetChainIdPattern));
 };


### PR DESCRIPTION
Closes #62 

Tested on multiple local devnets. Found the pattern that they all have a hexadecimal ending string of length 8. Preview nets prefix this string with an '-x'. That's why I simply extended the `isTestnetPreviewChainId` function by updating the regexp