### PR TITLE
feat: #60: add `websites` to globals

### DIFF
--- a/input/globals.json
+++ b/input/globals.json
@@ -37,6 +37,26 @@
       ]
     }
   ],
+  "websites": [
+    {
+      "name": "Silent Validator",
+      "url": "https://penumbra.silentvalidator.com",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/silent-validator.png"
+        }
+      ]
+    },
+    {
+      "name": "Starling Cybernetics",
+      "url": "https://stake.with.starlingcyber.net",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/starling-cybernetics.svg"
+        }
+      ]
+    }
+  ],
   "frontends": [
     "https://penumbra.silentvalidator.com",
     "https://stake.with.starlingcyber.net"

--- a/input/globals.json
+++ b/input/globals.json
@@ -37,7 +37,11 @@
       ]
     }
   ],
-  "websites": [
+  "frontends": [
+    "https://penumbra.silentvalidator.com",
+    "https://stake.with.starlingcyber.net"
+  ],
+  "frontendsV2": [
     {
       "name": "Silent Validator",
       "url": "https://penumbra.silentvalidator.com",
@@ -56,10 +60,6 @@
         }
       ]
     }
-  ],
-  "frontends": [
-    "https://penumbra.silentvalidator.com",
-    "https://stake.with.starlingcyber.net"
   ],
   "stakingAssetId": {
     "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="

--- a/npm/.changeset/chatty-onions-happen.md
+++ b/npm/.changeset/chatty-onions-happen.md
@@ -1,5 +1,0 @@
----
-'@penumbra-labs/registry': minor
----
-
-Add 'websites' field to globals. The same as 'frontends' (will be deprecated in the future) but with names and images

--- a/npm/.changeset/chatty-onions-happen.md
+++ b/npm/.changeset/chatty-onions-happen.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-labs/registry': minor
+---
+
+Add 'websites' field to globals. The same as 'frontends' (will be deprecated in the future) but with names and images

--- a/npm/.changeset/clever-keys-impress.md
+++ b/npm/.changeset/clever-keys-impress.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-labs/registry': major
+---
+
+New frontends data structure w/ images

--- a/npm/src/github.ts
+++ b/npm/src/github.ts
@@ -1,11 +1,11 @@
-import { Base64AssetId, Chain, Registry, Rpc } from './registry';
+import { Base64AssetId, Chain, Registry, EntityMetadata } from './registry';
 import { JsonGlobals, JsonMetadata } from './json';
 import { RegistryGlobals } from './globals';
 
 export interface GithubRegistryResponse {
   chainId: string;
   ibcConnections: Chain[];
-  rpcs: Rpc[];
+  rpcs: EntityMetadata[];
   assetById: Record<Base64AssetId, JsonMetadata>;
   stakingAssetId: Base64AssetId;
   numeraires: Base64AssetId[];

--- a/npm/src/globals.test.ts
+++ b/npm/src/globals.test.ts
@@ -4,6 +4,7 @@ import { JsonGlobals } from './json';
 
 const testGlobals: JsonGlobals = {
   rpcs: [{ name: 'rpc1', images: [], url: 'http://rpc1.com' }],
+  websites: [{ name: 'frontend1', images: [], url: 'http://example.com' }],
   frontends: ['frontend1', 'frontend2', 'frontend3'],
   stakingAssetId: {
     inner: 'KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=',

--- a/npm/src/globals.test.ts
+++ b/npm/src/globals.test.ts
@@ -4,7 +4,7 @@ import { JsonGlobals } from './json';
 
 const testGlobals: JsonGlobals = {
   rpcs: [{ name: 'rpc1', images: [], url: 'http://rpc1.com' }],
-  websites: [{ name: 'frontend1', images: [], url: 'http://example.com' }],
+  frontendsV2: [{ name: 'frontend1', images: [], url: 'http://example.com' }],
   frontends: ['frontend1', 'frontend2', 'frontend3'],
   stakingAssetId: {
     inner: 'KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=',
@@ -15,6 +15,6 @@ describe('Globals', () => {
   it('versions correctly', async () => {
     const registry = new RegistryGlobals(testGlobals);
     const version = await registry.version();
-    expect(version).toEqual('7e4059f5641482cfc817222cb5cbd6f62174d578d8473ff4b0a13ef643363b7e');
+    expect(version).toEqual('fb3fb559596710d33d3a52946c6280162db1cbca7cc385fe9a3a320ebca40009');
   });
 });

--- a/npm/src/globals.ts
+++ b/npm/src/globals.ts
@@ -7,6 +7,7 @@ export class RegistryGlobals {
   readonly stakingAssetId: AssetId;
   readonly rpcs: Rpc[];
   readonly websites: Frontend[];
+  /** @deprecated use `websites` instead */
   readonly frontends: string[];
 
   constructor(json: JsonGlobals) {

--- a/npm/src/globals.ts
+++ b/npm/src/globals.ts
@@ -1,4 +1,4 @@
-import { Rpc } from './registry';
+import { Rpc, Frontend } from './registry';
 import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { JsonGlobals } from './json';
 import { sha256Hash } from './utils/sha256';
@@ -6,10 +6,12 @@ import { sha256Hash } from './utils/sha256';
 export class RegistryGlobals {
   readonly stakingAssetId: AssetId;
   readonly rpcs: Rpc[];
+  readonly websites: Frontend[];
   readonly frontends: string[];
 
   constructor(json: JsonGlobals) {
     this.rpcs = json.rpcs;
+    this.websites = json.websites;
     this.frontends = json.frontends;
     this.stakingAssetId = AssetId.fromJson(json.stakingAssetId);
   }

--- a/npm/src/globals.ts
+++ b/npm/src/globals.ts
@@ -1,19 +1,16 @@
-import { Rpc, Frontend } from './registry';
+import { EntityMetadata } from './registry';
 import { AssetId } from '@buf/penumbra-zone_penumbra.bufbuild_es/penumbra/core/asset/v1/asset_pb';
 import { JsonGlobals } from './json';
 import { sha256Hash } from './utils/sha256';
 
 export class RegistryGlobals {
   readonly stakingAssetId: AssetId;
-  readonly rpcs: Rpc[];
-  readonly websites: Frontend[];
-  /** @deprecated use `websites` instead */
-  readonly frontends: string[];
+  readonly rpcs: EntityMetadata[];
+  readonly frontends: EntityMetadata[];
 
   constructor(json: JsonGlobals) {
     this.rpcs = json.rpcs;
-    this.websites = json.websites;
-    this.frontends = json.frontends;
+    this.frontends = json.frontendsV2;
     this.stakingAssetId = AssetId.fromJson(json.stakingAssetId);
   }
 

--- a/npm/src/json.ts
+++ b/npm/src/json.ts
@@ -1,6 +1,6 @@
 import * as Deimos8 from '../../registry/chains/penumbra-testnet-deimos-8.json';
 import * as Penumbra1 from '../../registry/chains/penumbra-1.json';
-import { Base64AssetId, Chain, Rpc } from './registry';
+import { Base64AssetId, Chain, Frontend, Rpc } from './registry';
 
 export interface JsonRegistry {
   chainId: string;
@@ -11,6 +11,7 @@ export interface JsonRegistry {
 
 export interface JsonGlobals {
   rpcs: Rpc[];
+  websites: Frontend[];
   frontends: string[];
   stakingAssetId: { inner: string };
 }

--- a/npm/src/json.ts
+++ b/npm/src/json.ts
@@ -1,6 +1,6 @@
 import * as Deimos8 from '../../registry/chains/penumbra-testnet-deimos-8.json';
 import * as Penumbra1 from '../../registry/chains/penumbra-1.json';
-import { Base64AssetId, Chain, Frontend, Rpc } from './registry';
+import { Base64AssetId, Chain, EntityMetadata } from './registry';
 
 export interface JsonRegistry {
   chainId: string;
@@ -10,10 +10,10 @@ export interface JsonRegistry {
 }
 
 export interface JsonGlobals {
-  rpcs: Rpc[];
-  websites: Frontend[];
-  /** @deprecated use `websites` instead */
+  rpcs: EntityMetadata[];
+  /** @deprecated use `frontendsV2` instead */
   frontends: string[];
+  frontendsV2: EntityMetadata[];
   stakingAssetId: { inner: string };
 }
 

--- a/npm/src/json.ts
+++ b/npm/src/json.ts
@@ -12,6 +12,7 @@ export interface JsonRegistry {
 export interface JsonGlobals {
   rpcs: Rpc[];
   websites: Frontend[];
+  /** @deprecated use `websites` instead */
   frontends: string[];
   stakingAssetId: { inner: string };
 }

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -23,13 +23,7 @@ export interface Chain {
   displayName: string;
 }
 
-export interface Rpc {
-  name: string;
-  url: string;
-  images: Image[];
-}
-
-export interface Frontend {
+export interface EntityMetadata {
   name: string;
   url: string;
   images: Image[];

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -29,6 +29,12 @@ export interface Rpc {
   images: Image[];
 }
 
+export interface Frontend {
+  name: string;
+  url: string;
+  images: Image[];
+}
+
 export interface Image {
   png?: string;
   svg?: string;

--- a/npm/src/remote.test.ts
+++ b/npm/src/remote.test.ts
@@ -57,5 +57,6 @@ describe('RemoteClient', () => {
     expect(registry.stakingAssetId.toJson()).toEqual(GlobalsJson.stakingAssetId);
     expect(registry.frontends).toEqual(GlobalsJson.frontends);
     expect(registry.rpcs).toEqual(GlobalsJson.rpcs);
+    expect(registry.websites).toEqual(GlobalsJson.websites);
   });
 });

--- a/npm/src/remote.test.ts
+++ b/npm/src/remote.test.ts
@@ -55,8 +55,7 @@ describe('RemoteClient', () => {
 
     expect(fetchMock.called(endpoint)).toBe(true);
     expect(registry.stakingAssetId.toJson()).toEqual(GlobalsJson.stakingAssetId);
-    expect(registry.frontends).toEqual(GlobalsJson.frontends);
+    expect(registry.frontends).toEqual(GlobalsJson.frontendsV2);
     expect(registry.rpcs).toEqual(GlobalsJson.rpcs);
-    expect(registry.websites).toEqual(GlobalsJson.websites);
   });
 });

--- a/registry/globals.json
+++ b/registry/globals.json
@@ -37,6 +37,26 @@
       ]
     }
   ],
+  "websites": [
+    {
+      "name": "Silent Validator",
+      "url": "https://penumbra.silentvalidator.com",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/silent-validator.png"
+        }
+      ]
+    },
+    {
+      "name": "Starling Cybernetics",
+      "url": "https://stake.with.starlingcyber.net",
+      "images": [
+        {
+          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/starling-cybernetics.svg"
+        }
+      ]
+    }
+  ],
   "frontends": [
     "https://penumbra.silentvalidator.com",
     "https://stake.with.starlingcyber.net"

--- a/registry/globals.json
+++ b/registry/globals.json
@@ -37,7 +37,11 @@
       ]
     }
   ],
-  "websites": [
+  "frontends": [
+    "https://penumbra.silentvalidator.com",
+    "https://stake.with.starlingcyber.net"
+  ],
+  "frontendsV2": [
     {
       "name": "Silent Validator",
       "url": "https://penumbra.silentvalidator.com",
@@ -56,10 +60,6 @@
         }
       ]
     }
-  ],
-  "frontends": [
-    "https://penumbra.silentvalidator.com",
-    "https://stake.with.starlingcyber.net"
   ],
   "stakingAssetId": {
     "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="

--- a/tools/compiler/Cargo.lock
+++ b/tools/compiler/Cargo.lock
@@ -651,8 +651,8 @@ dependencies = [
 
 [[package]]
 name = "decaf377-fmd"
-version = "0.79.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.79.0#54d114c668bd8ec78762ac7d682610b356f57fc8"
+version = "0.79.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.79.2#88a021eb715f21b3990c78e8df42c7c19e618c38"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -1514,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.11.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3b8be84e7285c73b88effdc3294b552277d6b0ec728ee016c861b7b9a2c19c"
+checksum = "18798160736c1e368938ba6967dbcb3c7afb3256b442a5506ba5222eebb68a5a"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1749,13 +1749,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1882,16 +1883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2059,8 +2050,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-asset"
-version = "0.79.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.79.0#54d114c668bd8ec78762ac7d682610b356f57fc8"
+version = "0.79.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.79.2#88a021eb715f21b3990c78e8df42c7c19e618c38"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2097,8 +2088,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-num"
-version = "0.79.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.79.0#54d114c668bd8ec78762ac7d682610b356f57fc8"
+version = "0.79.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.79.2#88a021eb715f21b3990c78e8df42c7c19e618c38"
 dependencies = [
  "anyhow",
  "ark-ff",
@@ -2133,8 +2124,8 @@ dependencies = [
 
 [[package]]
 name = "penumbra-proto"
-version = "0.79.0"
-source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.79.0#54d114c668bd8ec78762ac7d682610b356f57fc8"
+version = "0.79.2"
+source = "git+https://github.com/penumbra-zone/penumbra.git?tag=v0.79.2#88a021eb715f21b3990c78e8df42c7c19e618c38"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2815,9 +2806,9 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -2833,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote",
@@ -2844,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -3177,18 +3168,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote",
@@ -3253,28 +3244,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "d040ac2b29ab03b09d4129c2f5bbd012a3ac2f79d38ff506a4bf8dd34b0eac8a"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote",

--- a/tools/compiler/Cargo.toml
+++ b/tools/compiler/Cargo.toml
@@ -4,17 +4,17 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.79.0", package = "penumbra-asset" }
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.79.0", package = "penumbra-proto", default-features = false }
+penumbra-asset = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.79.2", package = "penumbra-asset" }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra.git", tag = "v0.79.2", package = "penumbra-proto", default-features = false }
 
 anyhow = "1.0.86"
 futures = "0.3.30"
-serde = { version = "1.0.203", features = ["derive"] }
-serde_json = "1.0.118"
+serde = { version = "1.0.204", features = ["derive"] }
+serde_json = "1.0.120"
 regress = "0.10.0"
 reqwest = { version = "0.12.5", features = ["json"] }
 tempdir = "0.3.7"
-thiserror = "1.0.61"
-tokio = { version = "1.38.0", features = ["full"] }
+thiserror = "1.0.63"
+tokio = { version = "1.39.1", features = ["full"] }
 tracing-subscriber = "0.3.18"
 tracing = "0.1.40"

--- a/tools/compiler/src/parser.rs
+++ b/tools/compiler/src/parser.rs
@@ -11,9 +11,10 @@ use crate::processor::Globals;
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalsInput {
-    pub rpcs: Vec<Rpc>,
-    pub websites: Vec<Frontend>,
+    pub rpcs: Vec<EntityMetadata>,
+    #[deprecated]
     pub frontends: Vec<String>,
+    pub frontends_v2: Vec<EntityMetadata>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -27,14 +28,7 @@ pub struct ChainConfig {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Rpc {
-    pub name: String,
-    pub url: String,
-    pub images: Vec<Image>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Frontend {
+pub struct EntityMetadata {
     pub name: String,
     pub url: String,
     pub images: Vec<Image>,

--- a/tools/compiler/src/parser.rs
+++ b/tools/compiler/src/parser.rs
@@ -12,6 +12,7 @@ use crate::processor::Globals;
 #[serde(rename_all = "camelCase")]
 pub struct GlobalsInput {
     pub rpcs: Vec<Rpc>,
+    pub websites: Vec<Frontend>,
     pub frontends: Vec<String>,
 }
 
@@ -27,6 +28,13 @@ pub struct ChainConfig {
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Rpc {
+    pub name: String,
+    pub url: String,
+    pub images: Vec<Image>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Frontend {
     pub name: String,
     pub url: String,
     pub images: Vec<Image>,

--- a/tools/compiler/src/processor.rs
+++ b/tools/compiler/src/processor.rs
@@ -7,7 +7,7 @@ use crate::error::{AppError, AppResult};
 use crate::github::assetlist_schema::AssetTypeAsset;
 use crate::parser::{
     copy_globals, get_chain_configs, reset_registry_dir, ChainConfig, GlobalsInput, IbcInput,
-    Image, Rpc, LOCAL_INPUT_DIR, LOCAL_REGISTRY_DIR,
+    Image, Rpc, Frontend, LOCAL_INPUT_DIR, LOCAL_REGISTRY_DIR,
 };
 use crate::querier::query_github_assets;
 use crate::validator::generate_metadata_from_validators;
@@ -45,6 +45,7 @@ impl From<IbcInput> for Chain {
 #[serde(rename_all = "camelCase")]
 pub struct Globals {
     pub rpcs: Vec<Rpc>,
+    pub websites: Vec<Frontend>,
     pub frontends: Vec<String>,
     pub staking_asset_id: Id,
 }
@@ -55,6 +56,7 @@ impl TryFrom<GlobalsInput> for Globals {
     fn try_from(g: GlobalsInput) -> AppResult<Self> {
         Ok(Globals {
             rpcs: g.rpcs,
+            websites: g.websites,
             frontends: g.frontends,
             staking_asset_id: *STAKING_TOKEN_ASSET_ID,
         })

--- a/tools/compiler/src/processor.rs
+++ b/tools/compiler/src/processor.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use crate::error::{AppError, AppResult};
 use crate::github::assetlist_schema::AssetTypeAsset;
 use crate::parser::{
-    copy_globals, get_chain_configs, reset_registry_dir, ChainConfig, GlobalsInput, IbcInput,
-    Image, Rpc, Frontend, LOCAL_INPUT_DIR, LOCAL_REGISTRY_DIR,
+    copy_globals, get_chain_configs, reset_registry_dir, ChainConfig, EntityMetadata, GlobalsInput,
+    IbcInput, Image, LOCAL_INPUT_DIR, LOCAL_REGISTRY_DIR,
 };
 use crate::querier::query_github_assets;
 use crate::validator::generate_metadata_from_validators;
@@ -44,9 +44,10 @@ impl From<IbcInput> for Chain {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Globals {
-    pub rpcs: Vec<Rpc>,
-    pub websites: Vec<Frontend>,
+    pub rpcs: Vec<EntityMetadata>,
+    #[deprecated]
     pub frontends: Vec<String>,
+    pub frontends_v2: Vec<EntityMetadata>,
     pub staking_asset_id: Id,
 }
 
@@ -54,10 +55,11 @@ impl TryFrom<GlobalsInput> for Globals {
     type Error = AppError;
 
     fn try_from(g: GlobalsInput) -> AppResult<Self> {
+        #![allow(deprecated)]
         Ok(Globals {
             rpcs: g.rpcs,
-            websites: g.websites,
             frontends: g.frontends,
+            frontends_v2: g.frontends_v2,
             staking_asset_id: *STAKING_TOKEN_ASSET_ID,
         })
     }

--- a/tools/compiler/tests/test_copy_globals.rs
+++ b/tools/compiler/tests/test_copy_globals.rs
@@ -1,5 +1,5 @@
 use penumbra_asset::STAKING_TOKEN_ASSET_ID;
-use penumbra_registry::parser::{copy_globals, GlobalsInput, Rpc, Frontend};
+use penumbra_registry::parser::{copy_globals, EntityMetadata, GlobalsInput};
 use penumbra_registry::processor::Globals;
 use std::fs::{self, File};
 use std::io::Write;
@@ -13,16 +13,17 @@ fn create_file_with_content(dir: &Path, file_name: &str, content: &str) {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_successful_copy() {
     let temp_input_dir = TempDir::new("").unwrap();
     let temp_output_dir = TempDir::new("").unwrap();
     let globals = GlobalsInput {
-        rpcs: vec![Rpc {
+        rpcs: vec![EntityMetadata {
             name: "cybernetics".to_string(),
             url: "http://api.zone".to_string(),
             images: vec![],
         }],
-        websites: vec![Frontend {
+        frontends_v2: vec![EntityMetadata {
             name: "cybernetics".to_string(),
             url: "http://api.zone".to_string(),
             images: vec![],
@@ -45,9 +46,8 @@ fn test_successful_copy() {
     let output_contents = fs::read_to_string(output_path).unwrap();
     let output_globals: Globals = serde_json::from_str(&output_contents).unwrap();
 
-    assert_eq!(output_globals.frontends, globals.frontends);
     assert_eq!(output_globals.rpcs, globals.rpcs);
-    assert_eq!(output_globals.websites, globals.websites);
+    assert_eq!(output_globals.frontends_v2, globals.frontends_v2);
     assert_eq!(output_globals.staking_asset_id, *STAKING_TOKEN_ASSET_ID);
 }
 

--- a/tools/compiler/tests/test_copy_globals.rs
+++ b/tools/compiler/tests/test_copy_globals.rs
@@ -1,5 +1,5 @@
 use penumbra_asset::STAKING_TOKEN_ASSET_ID;
-use penumbra_registry::parser::{copy_globals, GlobalsInput, Rpc};
+use penumbra_registry::parser::{copy_globals, GlobalsInput, Rpc, Frontend};
 use penumbra_registry::processor::Globals;
 use std::fs::{self, File};
 use std::io::Write;
@@ -18,6 +18,11 @@ fn test_successful_copy() {
     let temp_output_dir = TempDir::new("").unwrap();
     let globals = GlobalsInput {
         rpcs: vec![Rpc {
+            name: "cybernetics".to_string(),
+            url: "http://api.zone".to_string(),
+            images: vec![],
+        }],
+        websites: vec![Frontend {
             name: "cybernetics".to_string(),
             url: "http://api.zone".to_string(),
             images: vec![],
@@ -42,6 +47,7 @@ fn test_successful_copy() {
 
     assert_eq!(output_globals.frontends, globals.frontends);
     assert_eq!(output_globals.rpcs, globals.rpcs);
+    assert_eq!(output_globals.websites, globals.websites);
     assert_eq!(output_globals.staking_asset_id, *STAKING_TOKEN_ASSET_ID);
 }
 

--- a/tools/compiler/tests/test_get_chain_configs.rs
+++ b/tools/compiler/tests/test_get_chain_configs.rs
@@ -20,6 +20,7 @@ fn test_get_chain_configs_reads_configs_correctly() {
     let config_content = serde_json::json!({
         "chainId": "test-chain-1",
         "rpcs": [],
+        "websites": [],
         "frontends": [],
         "ibcConnections": [],
         "validators": [],
@@ -41,6 +42,7 @@ fn test_get_chain_configs_reads_multiple_configs_correctly() {
     let config_content_1 = serde_json::json!({
         "chainId": "test-chain-1",
         "rpcs": [],
+        "websites": [],
         "frontends": [],
         "ibcConnections": [],
         "validators": [],
@@ -58,6 +60,7 @@ fn test_get_chain_configs_reads_multiple_configs_correctly() {
     let config_content_2 = serde_json::json!({
         "chainId": "test-chain-2",
         "rpcs": [],
+        "websites": [],
         "frontends": [],
         "ibcConnections": [],
         "validators": [],

--- a/tools/compiler/tests/test_get_chain_configs.rs
+++ b/tools/compiler/tests/test_get_chain_configs.rs
@@ -20,7 +20,7 @@ fn test_get_chain_configs_reads_configs_correctly() {
     let config_content = serde_json::json!({
         "chainId": "test-chain-1",
         "rpcs": [],
-        "websites": [],
+        "frontendsV2": [],
         "frontends": [],
         "ibcConnections": [],
         "validators": [],
@@ -42,7 +42,7 @@ fn test_get_chain_configs_reads_multiple_configs_correctly() {
     let config_content_1 = serde_json::json!({
         "chainId": "test-chain-1",
         "rpcs": [],
-        "websites": [],
+        "frontendsV2": [],
         "frontends": [],
         "ibcConnections": [],
         "validators": [],
@@ -60,7 +60,7 @@ fn test_get_chain_configs_reads_multiple_configs_correctly() {
     let config_content_2 = serde_json::json!({
         "chainId": "test-chain-2",
         "rpcs": [],
-        "websites": [],
+        "frontendsV2": [],
         "frontends": [],
         "ibcConnections": [],
         "validators": [],


### PR DESCRIPTION
Closes #60 

Add the `websites` field to `globals`. The same as `frontends` but with `name` and `images` fields, following RPC structure