### PR TITLE
fix: export phobos-2 registry

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @penumbra-labs/registry
 
+## 11.3.1
+
+### Patch Changes
+
+- bundle phobos-2 registry, missing from v11.3.0
+
 ## 11.3.0
 
 ### Minor Changes

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-labs/registry",
-  "version": "11.3.0",
+  "version": "11.3.1",
   "description": "Chain and asset registry for Penumbra",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/npm/src/json.ts
+++ b/npm/src/json.ts
@@ -1,6 +1,7 @@
 import * as Deimos8 from '../../registry/chains/penumbra-testnet-deimos-8-x6de97e39.json';
 import * as Penumbra1 from '../../registry/chains/penumbra-1.json';
 import * as Phobos1 from '../../registry/chains/penumbra-testnet-phobos-1.json';
+import * as Phobos2 from '../../registry/chains/penumbra-testnet-phobos-2.json';
 import { Base64AssetId, Chain, EntityMetadata } from './registry';
 
 export interface JsonRegistry {
@@ -52,4 +53,5 @@ export const allJsonRegistries: Record<string, JsonRegistry> = {
   'penumbra-testnet-deimos-8-x6de97e39': Deimos8,
   'penumbra-1': Penumbra1,
   'penumbra-testnet-phobos-1': Phobos1,
+  'penumbra-testnet-phobos-2': Phobos2,
 };


### PR DESCRIPTION
Follow-up to #92, in which we overlooked a small change required to ship the new asset registry in #91. Refs https://github.com/penumbra-zone/dex-explorer/issues/57.