### PR TITLE
Remove permission limit from github action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,6 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     defaults:
       run:
         working-directory: npm


### PR DESCRIPTION
Diagnosing failing run: https://github.com/prax-wallet/registry/actions/runs/11475999397

This permission prevents the action from running with the correct permissions