### PR TITLE
Ignore unknown fields

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @penumbra-labs/registry
 
+## 12.0.0
+
+### Major Changes
+
+- Forward compatible Metadata deserialization
+
 ## 11.5.0
 
 ### Minor Changes

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-labs/registry",
-  "version": "11.5.0",
+  "version": "12.0.0",
   "description": "Chain and asset registry for Penumbra",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/npm/src/globals.ts
+++ b/npm/src/globals.ts
@@ -11,7 +11,7 @@ export class RegistryGlobals {
   constructor(json: JsonGlobals) {
     this.rpcs = json.rpcs;
     this.frontends = json.frontendsV2;
-    this.stakingAssetId = AssetId.fromJson(json.stakingAssetId);
+    this.stakingAssetId = AssetId.fromJson(json.stakingAssetId, { ignoreUnknownFields: true });
   }
 
   async version(): Promise<string> {

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -42,7 +42,7 @@ export class Registry {
     this.chainId = r.chainId;
     this.ibcConnections = r.ibcConnections;
     this.assetById = mapObjectValues(r.assetById, jsonMetadata =>
-      Metadata.fromJson(jsonMetadata as unknown as JsonValue),
+      Metadata.fromJson(jsonMetadata as unknown as JsonValue, { ignoreUnknownFields: true }),
     );
     this.numeraires = r.numeraires.map(a => new AssetId({ inner: base64ToUint8Array(a) }));
   }


### PR DESCRIPTION
Relates to https://github.com/prax-wallet/registry/pull/107

Given the new badges field, when deserializing Json, it's important to have the `ignoreUnknownFields` field set. If not, forward compatible Metadata changes will throw an error. This future proofs this type.

We will have to update frontends to this new registry version (and wait some time) before re-adding badges in main. 