### PR TITLE
feat: add name and description to Penumbra token

### DIFF
--- a/input/chains/penumbra-1.json
+++ b/input/chains/penumbra-1.json
@@ -91,6 +91,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/input/chains/penumbra-testnet-deimos-8-x6de97e39.json
+++ b/input/chains/penumbra-testnet-deimos-8-x6de97e39.json
@@ -57,6 +57,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/input/chains/penumbra-testnet-phobos-1.json
+++ b/input/chains/penumbra-testnet-phobos-1.json
@@ -57,6 +57,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/input/chains/penumbra-testnet-phobos-2-x4120f355.json
+++ b/input/chains/penumbra-testnet-phobos-2-x4120f355.json
@@ -66,6 +66,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/input/chains/penumbra-testnet-phobos-2.json
+++ b/input/chains/penumbra-testnet-phobos-2.json
@@ -79,6 +79,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/npm/.changeset/spotty-carpets-bathe.md
+++ b/npm/.changeset/spotty-carpets-bathe.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-labs/registry': patch
+---
+
+Add name and description fields to native Penumbra token in the registry

--- a/registry/chains/penumbra-1.json
+++ b/registry/chains/penumbra-1.json
@@ -719,6 +719,7 @@
       ]
     },
     "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=": {
+      "description": "The native token of Penumbra",
       "denomUnits": [
         {
           "denom": "penumbra",
@@ -734,9 +735,8 @@
       ],
       "base": "upenumbra",
       "display": "penumbra",
-      "symbol": "UM",
       "name": "Penumbra",
-      "description": "The native token of Penumbra",
+      "symbol": "UM",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-1.json
+++ b/registry/chains/penumbra-1.json
@@ -735,6 +735,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-testnet-deimos-8-x6de97e39.json
+++ b/registry/chains/penumbra-testnet-deimos-8-x6de97e39.json
@@ -153,6 +153,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-testnet-deimos-8-x6de97e39.json
+++ b/registry/chains/penumbra-testnet-deimos-8-x6de97e39.json
@@ -137,6 +137,7 @@
       ]
     },
     "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=": {
+      "description": "The native token of Penumbra",
       "denomUnits": [
         {
           "denom": "penumbra",
@@ -152,9 +153,8 @@
       ],
       "base": "upenumbra",
       "display": "penumbra",
-      "symbol": "UM",
       "name": "Penumbra",
-      "description": "The native token of Penumbra",
+      "symbol": "UM",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-testnet-phobos-1.json
+++ b/registry/chains/penumbra-testnet-phobos-1.json
@@ -163,6 +163,7 @@
       ]
     },
     "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=": {
+      "description": "The native token of Penumbra",
       "denomUnits": [
         {
           "denom": "penumbra",
@@ -178,9 +179,8 @@
       ],
       "base": "upenumbra",
       "display": "penumbra",
-      "symbol": "UM",
       "name": "Penumbra",
-      "description": "The native token of Penumbra",
+      "symbol": "UM",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-testnet-phobos-1.json
+++ b/registry/chains/penumbra-testnet-phobos-1.json
@@ -179,6 +179,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-testnet-phobos-2-x4120f355.json
+++ b/registry/chains/penumbra-testnet-phobos-2-x4120f355.json
@@ -153,6 +153,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-testnet-phobos-2-x4120f355.json
+++ b/registry/chains/penumbra-testnet-phobos-2-x4120f355.json
@@ -137,6 +137,7 @@
       ]
     },
     "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=": {
+      "description": "The native token of Penumbra",
       "denomUnits": [
         {
           "denom": "penumbra",
@@ -152,9 +153,8 @@
       ],
       "base": "upenumbra",
       "display": "penumbra",
-      "symbol": "UM",
       "name": "Penumbra",
-      "description": "The native token of Penumbra",
+      "symbol": "UM",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-testnet-phobos-2.json
+++ b/registry/chains/penumbra-testnet-phobos-2.json
@@ -181,6 +181,8 @@
       "base": "upenumbra",
       "display": "penumbra",
       "symbol": "UM",
+      "name": "Penumbra",
+      "description": "The native token of Penumbra",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },

--- a/registry/chains/penumbra-testnet-phobos-2.json
+++ b/registry/chains/penumbra-testnet-phobos-2.json
@@ -165,6 +165,7 @@
       "priorityScore": "900"
     },
     "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA=": {
+      "description": "The native token of Penumbra",
       "denomUnits": [
         {
           "denom": "penumbra",
@@ -180,9 +181,8 @@
       ],
       "base": "upenumbra",
       "display": "penumbra",
-      "symbol": "UM",
       "name": "Penumbra",
-      "description": "The native token of Penumbra",
+      "symbol": "UM",
       "penumbraAssetId": {
         "inner": "KeqcLzNx9qSH5+lcJHBB9KNW+YPrBk5dKzvPMiypahA="
       },


### PR DESCRIPTION
It felt wrong that the native token didn't have name and description in its own registry. Also, it feels logical to tokens filter by name, so searching for "penumbra" in different products couldn't find the UM token

Let me know if there could be a better text in the description field