### PR TITLE
registry: let downstream override base url

### DIFF
--- a/npm/src/github.ts
+++ b/npm/src/github.ts
@@ -11,7 +11,7 @@ export interface GithubRegistryResponse {
   numeraires: Base64AssetId[];
 }
 
-const DEFAULT_REGISTRY_BASE_URL =
+export const DEFAULT_REGISTRY_BASE_URL =
   'https://raw.githubusercontent.com/prax-wallet/registry/main/registry';
 
 type ChainId = string;

--- a/npm/src/github.ts
+++ b/npm/src/github.ts
@@ -11,21 +11,23 @@ export interface GithubRegistryResponse {
   numeraires: Base64AssetId[];
 }
 
-export const REGISTRY_BASE_URL =
+const DEFAULT_REGISTRY_BASE_URL =
   'https://raw.githubusercontent.com/prax-wallet/registry/main/registry';
 
 type ChainId = string;
 
 export class GithubFetcher {
+  constructor(private baseUrl: string = DEFAULT_REGISTRY_BASE_URL) {}
+
   async fetchRegistry(chainId: ChainId): Promise<Registry> {
-    const response = await this.typedFetcher<GithubRegistryResponse>(
-      `${REGISTRY_BASE_URL}/chains/${chainId}.json`,
+  const response = await this.typedFetcher<GithubRegistryResponse>(
+      `${this.baseUrl}/chains/${chainId}.json`,
     );
     return new Registry(response);
   }
 
   async fetchGlobals(): Promise<RegistryGlobals> {
-    const response = await this.typedFetcher<JsonGlobals>(`${REGISTRY_BASE_URL}/globals.json`);
+    const response = await this.typedFetcher<JsonGlobals>(`${this.baseUrl}/globals.json`);
     return new RegistryGlobals(response);
   }
 

--- a/npm/src/remote.test.ts
+++ b/npm/src/remote.test.ts
@@ -1,7 +1,7 @@
 import { it, describe, expect, beforeEach, afterEach } from 'vitest';
 import fetchMock from 'fetch-mock';
 import { RemoteClient } from './remote';
-import { REGISTRY_BASE_URL } from './github';
+import { DEFAULT_REGISTRY_BASE_URL } from './github';
 import { ChainRegistryClient } from './client';
 import * as Phobos1 from '../../registry/chains/penumbra-testnet-phobos-1.json';
 import * as GlobalsJson from '../../registry/globals.json';
@@ -23,7 +23,7 @@ describe('RemoteClient', () => {
 
   it('should fetch registry remotely and parse it', async () => {
     const chainId = 'test-chain-7';
-    const endpoint = `${REGISTRY_BASE_URL}/chains/${chainId}.json`;
+    const endpoint = `${DEFAULT_REGISTRY_BASE_URL}/chains/${chainId}.json`;
     fetchMock.get(endpoint, {
       status: 200,
       body: Phobos1,
@@ -39,7 +39,7 @@ describe('RemoteClient', () => {
 
   it('should throw if there is not a remote version', async () => {
     const chainId = 'test-not-real-3242';
-    const endpoint = `${REGISTRY_BASE_URL}/chains/${chainId}.json`;
+    const endpoint = `${DEFAULT_REGISTRY_BASE_URL}/chains/${chainId}.json`;
     fetchMock.get(endpoint, {
       status: 404,
     });
@@ -47,7 +47,7 @@ describe('RemoteClient', () => {
   });
 
   it('should fetch globals remotely and parse it', async () => {
-    const endpoint = `${REGISTRY_BASE_URL}/globals.json`;
+    const endpoint = `${DEFAULT_REGISTRY_BASE_URL}/globals.json`;
     fetchMock.get(endpoint, {
       status: 200,
       body: GlobalsJson,
@@ -64,12 +64,12 @@ describe('RemoteClient', () => {
   describe('testnet preview', () => {
     it('fetches falls back if available', async () => {
       const testnetPreviewChainId = 'penumbra-testnet-phobos-1-x6de97e39';
-      const firstCall = `${REGISTRY_BASE_URL}/chains/${testnetPreviewChainId}.json`;
+      const firstCall = `${DEFAULT_REGISTRY_BASE_URL}/chains/${testnetPreviewChainId}.json`;
       fetchMock.get(firstCall, {
         status: 404,
       });
       const fallbackChainId = 'penumbra-testnet-phobos-1';
-      const secondCall = `${REGISTRY_BASE_URL}/chains/${fallbackChainId}.json`;
+      const secondCall = `${DEFAULT_REGISTRY_BASE_URL}/chains/${fallbackChainId}.json`;
       fetchMock.get(secondCall, {
         status: 200,
         body: Phobos1,
@@ -86,12 +86,12 @@ describe('RemoteClient', () => {
 
     it('throws if falls back not available', async () => {
       const testnetPreviewChainId = 'penumbra-testnet-phobos-1-x6de97e39';
-      const firstCall = `${REGISTRY_BASE_URL}/chains/${testnetPreviewChainId}.json`;
+      const firstCall = `${DEFAULT_REGISTRY_BASE_URL}/chains/${testnetPreviewChainId}.json`;
       fetchMock.get(firstCall, {
         status: 404,
       });
       const fallbackChainId = 'penumbra-testnet-phobos-1';
-      const secondCall = `${REGISTRY_BASE_URL}/chains/${fallbackChainId}.json`;
+      const secondCall = `${DEFAULT_REGISTRY_BASE_URL}/chains/${fallbackChainId}.json`;
       fetchMock.get(secondCall, {
         status: 404,
       });
@@ -108,7 +108,7 @@ describe('RemoteClient', () => {
   describe('getWithBundledBackup', () => {
     it('fetches remote when available', async () => {
       const chainId = 'test-chain-7';
-      const endpoint = `${REGISTRY_BASE_URL}/chains/${chainId}.json`;
+      const endpoint = `${DEFAULT_REGISTRY_BASE_URL}/chains/${chainId}.json`;
       fetchMock.get(endpoint, {
         status: 200,
         body: Phobos1,
@@ -124,7 +124,7 @@ describe('RemoteClient', () => {
 
     it('fetches bundled when available', async () => {
       const chainId = 'penumbra-testnet-phobos-1';
-      const endpoint = `${REGISTRY_BASE_URL}/chains/${chainId}.json`;
+      const endpoint = `${DEFAULT_REGISTRY_BASE_URL}/chains/${chainId}.json`;
       fetchMock.get(endpoint, {
         status: 404,
       });

--- a/npm/src/remote.ts
+++ b/npm/src/remote.ts
@@ -4,10 +4,20 @@ import { RegistryGlobals } from './globals';
 import { BundledClient } from './bundled';
 import { deriveTestnetChainIdFromPreview, isTestnetPreviewChainId } from './utils/testnet-parser';
 
-export class RemoteClient {
-  private readonly github = new GithubFetcher();
+interface RemoteClientOptions {
+  // erwan: we can override this baseUrl with a custom one, e.g, using a branch.
+  baseUrl?: string;
+}
 
-  constructor(private readonly bundled: BundledClient) {}
+export class RemoteClient {
+  private readonly github: GithubFetcher;
+
+  constructor(
+    private readonly bundled: BundledClient,
+    options?: RemoteClientOptions,
+  ) {
+    this.github = new GithubFetcher(options?.baseUrl);
+  }
 
   async get(chainId: string): Promise<Registry> {
     try {


### PR DESCRIPTION
Exploring if this is feasible. The reason why this is desirable is that this would let us experiment with custom registries on a whim, for example, if we are setting up devnet with custom channels.

Without this, it's near impossible to use registry downstreams on custom networks. 

Not tested