### PR TITLE
fix: get metadata by denom using base field

### DIFF
--- a/npm/.changeset/healthy-chairs-mate.md
+++ b/npm/.changeset/healthy-chairs-mate.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-labs/registry': patch
+---
+
+Fix querying metadata by denom – should use `base` field instead of `denom`

--- a/npm/src/registry.test.ts
+++ b/npm/src/registry.test.ts
@@ -19,7 +19,7 @@ describe('Registry', () => {
 
   it('gets metadata by asset denom successfully', () => {
     const registry = new Registry(testRegistry);
-    const res = registry.getMetadata(new Denom({ denom: 'penumbra' }));
+    const res = registry.getMetadata(new Denom({ denom: 'upenumbra' }));
     expect(res.base).toEqual('upenumbra');
   });
 

--- a/npm/src/registry.ts
+++ b/npm/src/registry.ts
@@ -53,7 +53,7 @@ export class Registry {
       });
 
       this.assetById[key] = metadata;
-      this.assetByDenom[metadata.display] = metadata;
+      this.assetByDenom[metadata.base] = metadata;
     });
   }
 


### PR DESCRIPTION
Querying metadata by denom should use `base` field instead of `display`