### PR TITLE
add nix flake for dev env

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 /.idea
 node_modules
 **/dist
+
+# direnv
+.envrc
+.direnv/
+
+# tarballs
+*.tgz

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Let's say you want to add or edit an asset in the registry. Here are the steps y
 8. After merge, the latest registry will be live in `registry/` and available in the newly published npm package
    version.
 
+There's a [nix](https://nixos.org/download/) flake in the repo that will pull in the relevant tooling, such as Rust and pnpm.
+
 ### File structure
 
 The generator expects a specific directory structure:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1744386647,
+        "narHash": "sha256-DXwQEJllxpYeVOiSlBhQuGjfvkoGHTtILLYO2FvcyzQ=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "d02c1cdd7ec539699aa44e6ff912e15535969803",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739206421,
+        "narHash": "sha256-PwQASeL2cGVmrtQYlrBur0U20Xy07uSWVnFup2PHnDs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "44534bc021b85c8d78e465021e21f33b856e2540",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Dev shell for Prax wallet asset registry";
+  # inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.crane.url = "github:ipetkov/crane";
+
+  outputs = { self, nixpkgs, flake-utils, crane }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        craneLib = (crane.mkLib pkgs);
+      in
+      {
+
+        devShells.default = craneLib.devShell {
+          name = "devShell";
+          nativeBuildInputs = [ pkgs.bashInteractive ];
+          buildInputs = with pkgs; [
+            fd
+            file
+            jq
+            just
+            openssl
+            pnpm
+            nodejs_22
+          ];
+        };
+      });
+}

--- a/justfile
+++ b/justfile
@@ -1,4 +1,10 @@
-# Update registry info JSON files
-run:
+# update registry info JSON files
+assets:
   cd tools/compiler && \
     RUST_LOG=penumbra_registry=debug cargo run
+
+# build the npm package from registry JSON files
+build:
+  cd npm && \
+    pnpm build && \
+    npm pack


### PR DESCRIPTION
Creates a nix flake to manage dev dependencies, same as present in the other related dependency repos, such as web [0]. My goal in submitting this PR is simply to make life easier for developers when switching between repos, provided they've some familiarity with nix.

The nix flake provides a devshell, but does not declare any build targets. There's a `just build` wrapper for convenience.

[0] https://github.com/penumbra-zone/web