### PR TITLE
feat(npm): add phobos 3 to bundled npm registry

### DIFF
--- a/npm/.changeset/shaggy-dogs-attend.md
+++ b/npm/.changeset/shaggy-dogs-attend.md
@@ -1,0 +1,5 @@
+---
+'@penumbra-labs/registry': minor
+---
+
+Add Phobos3 bundled registry

--- a/npm/.changeset/shaggy-dogs-attend.md
+++ b/npm/.changeset/shaggy-dogs-attend.md
@@ -1,5 +1,0 @@
----
-'@penumbra-labs/registry': minor
----
-
-Add Phobos3 bundled registry

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @penumbra-labs/registry
 
+## 12.6.0
+
+### Minor Changes
+
+- a4e903b: Add Phobos3 bundled registry
+
 ## 12.5.1
 
 ### Patch Changes

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-labs/registry",
-  "version": "12.5.1",
+  "version": "12.6.0",
   "description": "Chain and asset registry for Penumbra",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/npm/src/json.ts
+++ b/npm/src/json.ts
@@ -2,6 +2,7 @@ import * as Deimos8 from '../../registry/chains/penumbra-testnet-deimos-8-x6de97
 import * as Penumbra1 from '../../registry/chains/penumbra-1.json';
 import * as Phobos1 from '../../registry/chains/penumbra-testnet-phobos-1.json';
 import * as Phobos2 from '../../registry/chains/penumbra-testnet-phobos-2.json';
+import * as Phobos3 from '../../registry/chains/penumbra-testnet-phobos-3.json';
 import { Base64AssetId, Chain, EntityMetadata } from './registry';
 
 export interface JsonRegistry {
@@ -55,4 +56,5 @@ export const allJsonRegistries: Record<string, JsonRegistry> = {
   'penumbra-1': Penumbra1,
   'penumbra-testnet-phobos-1': Phobos1,
   'penumbra-testnet-phobos-2': Phobos2,
+  'penumbra-testnet-phobos-3': Phobos3,
 };


### PR DESCRIPTION
Fixes the NPM registry for the Phobos3 chain and upgrades JS package version