### PR TITLE
remove Simply Staking from RPC list

### DIFF
--- a/input/globals.json
+++ b/input/globals.json
@@ -19,15 +19,6 @@
       ]
     },
     {
-      "name": "Simply Staking",
-      "url": "https://penumbra-grpc.simplystaking.xyz",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/simply-staking.png"
-        }
-      ]
-    },
-    {
       "name": "Silent Validator",
       "url": "https://grpc.penumbra.silentvalidator.com",
       "images": [

--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @penumbra-labs/registry
 
+## 12.7.2
+
+### Patch Changes
+
+- Remove Simply Staking RPC for downtime
+
 ## 12.7.1
 
 ### Patch Changes

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-labs/registry",
-  "version": "12.7.1",
+  "version": "12.7.2",
   "description": "Chain and asset registry for Penumbra",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/registry/globals.json
+++ b/registry/globals.json
@@ -19,15 +19,6 @@
       ]
     },
     {
-      "name": "Simply Staking",
-      "url": "https://penumbra-grpc.simplystaking.xyz",
-      "images": [
-        {
-          "png": "https://raw.githubusercontent.com/prax-wallet/registry/main/images/simply-staking.png"
-        }
-      ]
-    },
-    {
       "name": "Silent Validator",
       "url": "https://grpc.penumbra.silentvalidator.com",
       "images": [


### PR DESCRIPTION
The Simply Staking RPC endpoint is down, returning a 502. Radiant Commons helpfully wrangled the other community RPCs to updating to a new enough version of `pd` to support the new Frontier RPC [0], which is used by a forthcoming version of Prax [1]. Since Staking is down, they can't update, so let's remove them from the bundled list of RPC options. Once they're back up we can consider re-adding.

[0] https://github.com/penumbra-zone/penumbra/pull/5179
[1] https://github.com/prax-wallet/prax/pull/336