### PR TITLE
ci: fix changeset cwd to absolute path

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,7 +36,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm changeset:publish
-          cwd: "./npm"
+          cwd: "${{ github.workspace }}/npm"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Since release of v1.5.2 of the github action helper for changesets [0], relative paths are no longer working when specifying the cwd for the action. See more info in [1].

[0] https://github.com/changesets/action/releases/tag/v1.5.2
[1] https://github.com/changesets/action/issues/475