### PR TITLE
feat: allow consumers to enable caching for NextJS

### DIFF
--- a/npm/CHANGELOG.md
+++ b/npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @penumbra-labs/registry
 
+## 12.8.0
+
+### Minor Changes
+
+- Add an option to improve caching in NextJS environments.
+
 ## 12.7.2
 
 ### Patch Changes

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@penumbra-labs/registry",
-  "version": "12.7.2",
+  "version": "12.8.0",
   "description": "Chain and asset registry for Penumbra",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/npm/src/client.ts
+++ b/npm/src/client.ts
@@ -1,12 +1,13 @@
 import { BundledClient } from './bundled';
+import { RegistryOptions } from './options';
 import { RemoteClient } from './remote';
 
 export class ChainRegistryClient {
   public readonly bundled: BundledClient;
   public readonly remote: RemoteClient;
 
-  constructor() {
+  constructor(options?: RegistryOptions) {
     this.bundled = new BundledClient();
-    this.remote = new RemoteClient(this.bundled);
+    this.remote = new RemoteClient(this.bundled, options);
   }
 }

--- a/npm/src/github.ts
+++ b/npm/src/github.ts
@@ -1,6 +1,7 @@
 import { Base64AssetId, Chain, Registry, EntityMetadata } from './registry';
 import { JsonGlobals, JsonMetadata } from './json';
 import { RegistryGlobals } from './globals';
+import { RegistryOptions } from './options';
 
 export interface GithubRegistryResponse {
   chainId: string;
@@ -17,6 +18,8 @@ export const REGISTRY_BASE_URL =
 type ChainId = string;
 
 export class GithubFetcher {
+  constructor(private readonly options?: RegistryOptions) {}
+
   async fetchRegistry(chainId: ChainId): Promise<Registry> {
     const response = await this.typedFetcher<GithubRegistryResponse>(
       `${REGISTRY_BASE_URL}/chains/${chainId}.json`,
@@ -30,7 +33,14 @@ export class GithubFetcher {
   }
 
   private async typedFetcher<T>(url: string): Promise<T> {
-    const response = await fetch(url);
+    // If we figure that we're running on server side NextJS, we need to set
+    // 'force-cache', so that caching is enabled *at all*, because their silly
+    // polyfill messes up the default semantics of fetch.
+    //
+    // If we're in the browser, or not using NextJS, we're fine.
+    const cache =
+      this.options?.nextjsServerSide && typeof window === 'undefined' ? 'force-cache' : 'default';
+    const response = await fetch(url, { cache });
     if (!response.ok) {
       throw new Error(`Failed to fetch from: ${url}`);
     }

--- a/npm/src/options.ts
+++ b/npm/src/options.ts
@@ -1,0 +1,20 @@
+/** Options to configure the registry.
+ *
+ * In the browser, no tinkering should be needed.
+ *
+ * If you're using NextJS, you should consider adding the `nextjsServerSide` flag,
+ * when on the server.
+ */
+export interface RegistryOptions {
+  /** If set, this code is running on the server side of a NextJS app.
+   *
+   * This information is useful, because NextJS overrides the behavior of the
+   * `fetch` API, which the registry uses to get an up-to-date remote registry.
+   *
+   * We want to cache these results, which `fetch` will do just fine in the browser.
+   * But, by default, NextJS will not cache anything, ever.
+   * By informing the registry that it's running in this environment, it can amend
+   * its fetching behavior accordingly.
+   */
+  nextjsServerSide?: boolean;
+}

--- a/npm/src/remote.ts
+++ b/npm/src/remote.ts
@@ -3,11 +3,17 @@ import { GithubFetcher } from './github';
 import { RegistryGlobals } from './globals';
 import { BundledClient } from './bundled';
 import { deriveTestnetChainIdFromPreview, isTestnetPreviewChainId } from './utils/testnet-parser';
+import { RegistryOptions } from './options';
 
 export class RemoteClient {
-  private readonly github = new GithubFetcher();
+  private readonly github;
 
-  constructor(private readonly bundled: BundledClient) {}
+  constructor(
+    private readonly bundled: BundledClient,
+    options?: RegistryOptions,
+  ) {
+    this.github = new GithubFetcher(options);
+  }
 
   async get(chainId: string): Promise<Registry> {
     try {


### PR DESCRIPTION
By default, NextJS provides a polyfill of the fetch API: https://nextjs.org/docs/app/api-reference/functions/fetch

We use fetch to get the remote Github resources.
In the browser, our current code will use the browser cache well, caching the result based on the headers Github gives us, which, by default, cache it for 5 minutes.

On the server though, when using NextJS, caching will **never happen**. By default, their polyfilled fetch will not cache anything, and you instead need to pass `'force-cache'`.
Their semantics for this are the same as `'default'` in the browser.

We also can't just pass this option blindly, because in the browser, this will have the wrong effect, and always use the cache, even if stale.

So, we need to figure out if we're in NextJS, and modify the behavior accordingly.
I opted against some kind of wacky mechanism to detect NextJS via the presence of some environment variable, instead opting just to allow the user to tell us.

In our own code, this will then be a matter of just passing the option when we set up the global server side registry client. Seems ergonomic enough to me.