### PR TITLE
ci: pin version of changeset action helper

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,8 @@ jobs:
       # If there are none, it will publish newer-versioned public packages to npm
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        # Pin version for changeset action helper; refs https://github.com/prax-wallet/registry/issues/147
+        uses: changesets/action@v1.5.2
         with:
           publish: pnpm changeset:publish
           cwd: "${{ github.workspace }}/npm"


### PR DESCRIPTION
We've seen the changeset github action break twice within the past week. Let's the last known working version in order to unblock ongoing release mechanics.

Refs https://github.com/prax-wallet/registry/issues/147 but doesn't close; this is a temporary workaround.